### PR TITLE
Change default listen address from localhost to 0.0.0.0

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -25,7 +25,7 @@ pub struct Context {
 
 const DEFAULT_HTTP_PORT: u16 = 3000;
 const DEFAULT_WS_PORT: u16 = 4000;
-const DEFAULT_HOSTNAME: &'static str = "localhost";
+const DEFAULT_HOSTNAME: &'static str = "0.0.0.0";
 
 pub type SharedContext = Arc<Mutex<Context>>;
 


### PR DESCRIPTION
When you listen to an explicit IP address, then you only accept
connections over one particular interface (lo for localhost).
By using 0.0.0.0 connections will be accepted over any interface
(wifi, eth, lo, etc).
