### PR TITLE
Add command line options to parse http and ws port numbers

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -23,23 +23,25 @@ pub struct Context {
     services: HashMap<String, Box<Service>>
 }
 
-const DEFAULT_HTTP_PORT: u16 = 3000;
-const DEFAULT_WS_PORT: u16 = 4000;
+const DEFAULT_HTTP_PORT: &'static str = "3000";
+const DEFAULT_WS_PORT: &'static str = "4000";
 const DEFAULT_HOSTNAME: &'static str = "0.0.0.0";
 
 pub type SharedContext = Arc<Mutex<Context>>;
 
 impl Context {
-    pub fn new(verbose: bool, hostname: Option<String>) -> Context {
+    pub fn new(verbose: bool, hostname: Option<String>,
+               http_port: Option<String>, ws_port: Option<String>) -> Context {
         Context { services: HashMap::new(),
                   verbose: verbose,
                   hostname:  hostname.unwrap_or(DEFAULT_HOSTNAME.to_string()),
-                  http_port: DEFAULT_HTTP_PORT,
-                  ws_port: DEFAULT_WS_PORT }
+                  http_port: http_port.unwrap_or(DEFAULT_HTTP_PORT.to_string()).parse::<u16>().unwrap(),
+                  ws_port: ws_port.unwrap_or(DEFAULT_WS_PORT.to_string()).parse::<u16>().unwrap() }
     }
 
-    pub fn shared(verbose: bool, hostname: Option<String>) -> SharedContext {
-        Arc::new(Mutex::new(Context::new(verbose, hostname)))
+    pub fn shared(verbose: bool, hostname: Option<String>,
+                  http_port:Option<String>, ws_port:Option<String>) -> SharedContext {
+        Arc::new(Mutex::new(Context::new(verbose, hostname, http_port, ws_port)))
     }
 
     pub fn add_service(&mut self, service: Box<Service>) {

--- a/src/context.rs
+++ b/src/context.rs
@@ -25,7 +25,7 @@ pub struct Context {
 
 const DEFAULT_HTTP_PORT: u16 = 3000;
 const DEFAULT_WS_PORT: u16 = 4000;
-const DEFAULT_HOSTNAME: &'static str = "localhost";
+const DEFAULT_HOSTNAME: &'static str = "0.0.0.0";
 
 pub type SharedContext = Arc<Mutex<Context>>;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -45,6 +45,8 @@ fn main() {
     let mut opts = Options::new();
     opts.optflag("v", "verbose", "Toggle verbose output");
     opts.optopt("n", "name", "Set local host name", "HOSTNAME");
+    opts.optopt("p", "http-port", "Set port to listen on for http connections", "HTTP_PORT");
+    opts.optopt("w", "ws-port", "Set port to listen on for web services", "WS_PORT");
     opts.optflag("h", "help", "Print this help menu");
     let matches = match opts.parse(&args[1..]) {
         Ok(m) => { m }
@@ -62,7 +64,9 @@ fn main() {
         let sender = event_loop.channel();
 
         let context = Context::shared(matches.opt_present("v"),
-                                      matches.opt_str("n"));
+                                      matches.opt_str("n"),
+                                      matches.opt_str("p"),
+                                      matches.opt_str("w"),);
         let mut controler = Controler::new(sender, context);
         controler.start();
 


### PR DESCRIPTION
Some services, like ntop already use port 3000, so this allows alternate ports to be used.
