### PR TITLE
Add logging crates, and enable logging using the 'env_logging' crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,9 @@ version = "0.1.0"
 dependencies = [
  "clippy 0.0.37 (registry+https://github.com/rust-lang/crates.io-index)",
  "docopt 0.6.78 (registry+https://github.com/rust-lang/crates.io-index)",
+ "env_logger 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "iron 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "mio 0.5.0 (git+https://github.com/carllerche/mio.git)",
  "mount 0.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "router 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -64,7 +66,7 @@ name = "clippy"
 version = "0.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "semver 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "semver 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-normalization 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -84,7 +86,7 @@ dependencies = [
  "openssl 0.7.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.34 (registry+https://github.com/rust-lang/crates.io-index)",
- "url 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "url 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -95,6 +97,15 @@ dependencies = [
  "regex 0.1.48 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "strsim 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "log 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 0.1.48 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -154,7 +165,7 @@ dependencies = [
  "traitobject 0.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "typeable 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicase 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "url 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "url 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -171,7 +182,7 @@ dependencies = [
  "num_cpus 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "plugin 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "typemap 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "url 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "url 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -460,7 +471,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "semver"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "nom 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -531,7 +542,7 @@ dependencies = [
  "log 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "mount 0.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.34 (registry+https://github.com/rust-lang/crates.io-index)",
- "url 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "url 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -621,7 +632,7 @@ dependencies = [
 
 [[package]]
 name = "url"
-version = "0.5.3"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "matches 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -662,7 +673,7 @@ dependencies = [
  "rand 0.3.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicase 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "url 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "url 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,9 @@ build = "build.rs"
 [dependencies]
 clippy = "0.0.37"
 docopt = "0.6.78"
+env_logger = "0.3.2"
 iron = "0.2.6"
+log = "0.3"
 mio = { git = "https://github.com/carllerche/mio.git" }
 mount = "0.0.9"
 router = "0.1.0"

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,8 +15,11 @@
 
 extern crate core;
 extern crate docopt;
+extern crate env_logger;
 #[macro_use]
 extern crate iron;
+#[macro_use]
+extern crate log;
 extern crate mio;
 extern crate mount;
 extern crate router;
@@ -53,6 +56,8 @@ struct Args {
 }
 
 fn main() {
+    env_logger::init().unwrap();
+
     let args: Args = Docopt::new(USAGE)
         .and_then(|d| d.decode())
         .unwrap_or_else(|e| e.exit());


### PR DESCRIPTION
See https://doc.rust-lang.org/log/env_logger/index.html
and https://doc.rust-lang.org/log/log/index.html for usage.

**tl;dr;** 

Usage:
- `debug!`  - Logs a message at the debug level.
- `error!` - Logs a message at the error level.
- `info!` - Logs a message at the info level.
- `log!` - The standard logging macro.
- `log_enabled!` - Determines if a message logged at the specified level in that module will be logged.
- `trace!`  - Logs a message at the trace level.
- `warn!`  - Logs a message at the warn level.

Enable:
`RUST_LOG=<level> ./main`    - There is more to this though, see: https://doc.rust-lang.org/log/env_logger/index.html#enabling-logging
