### PR TITLE
Use docopt macro instead

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,6 +4,7 @@ version = "0.1.0"
 dependencies = [
  "clippy 0.0.37 (registry+https://github.com/rust-lang/crates.io-index)",
  "docopt 0.6.78 (registry+https://github.com/rust-lang/crates.io-index)",
+ "docopt_macros 0.6.80 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "iron 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -97,6 +98,14 @@ dependencies = [
  "regex 0.1.48 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "strsim 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "docopt_macros"
+version = "0.6.80"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "docopt 0.6.78 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ build = "build.rs"
 [dependencies]
 clippy = "0.0.37"
 docopt = "0.6.78"
+docopt_macros = "0.6.80"
 env_logger = "0.3.2"
 iron = "0.2.6"
 log = "0.3"


### PR DESCRIPTION
Using the macros make it simplier to add new command line arguments.

Since we use rust-nightly, the use of plugins is fine (which docopt require)
