### PR TITLE
more explicit node dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,6 @@ language: rust
 rust:
     - nightly
 
-addons:
-  hosts:
-    - foxbox.local
-
 before_script:
     - "sh -e /etc/init.d/xvfb start"
     - "export DISPLAY=:99.0"
@@ -14,10 +10,10 @@ before_script:
     - sleep 5
     - nvm install 4.2
     - nvm use 4.2
-    - npm install selenium-webdriver mocha jshint
+    - npm install
 
 script:
     - cargo build # Linter is also executed here
     - RUST_BACKTRACE=1 cargo test
     - jshint static/*.js test/selenium/*.js
-    - (cargo run &> /dev/null &) ; ./node_modules/.bin/mocha test/selenium/ftu_test.js
+    - (cargo run &> /dev/null &) ; npm test

--- a/package.json
+++ b/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "foxbox",
+  "version": "1.0.0",
+  "description": "The FoxBox daemon",
+  "engines": {
+    "node": ">=4.0.0"
+  },
+  "scripts": {
+    "test": "./node_modules/.bin/mocha test/selenium/ftu_test.js"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/fxbox/foxbox.git"
+  },
+  "author": "The FoxLink Team",
+  "license": "MPL-2.0",
+  "bugs": {
+    "url": "https://github.com/fxbox/foxbox/issues"
+  },
+  "homepage": "https://github.com/fxbox/foxbox",
+  "devDependencies": {
+    "jshint": "2.9.1",
+    "mocha": "2.4.5",
+    "selenium-webdriver": "2.48.2"
+  }
+}

--- a/test/selenium/ftu_test.js
+++ b/test/selenium/ftu_test.js
@@ -15,7 +15,7 @@ describe('setup page', function() {
       build();
   });
   beforeEach(function() {
-    driver.get('http://foxbox.local:3000/');
+    driver.get('http://localhost:3000/');
   });
   after(function() {
     driver.quit();


### PR DESCRIPTION
It wasn't obvious that I need to have a node to run the selenium tests. This PR adds a `package.json` file so we can have a proper place for dev dependencies as well as defining the version of node that is supported (via the `engines` key).

Now locally we can simply setup via:

``` bash
$ npm install
```

And then run the tests by having the Rust server running on port 3000 and:

``` bash
$ npm test
```

:pager: @michielbdejong @JohanLorenzo 

If this is ok with you I'd like to add some instructions about this to the readme before merging.
