### PR TITLE
Put test dependency out of regular build

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,4 +22,6 @@ serde_macros = "0.6.13"
 staticfile = "0.1.0"
 uuid = "0.1.18"
 websocket = "0.15.0"
+
+[dev-dependencies]
 stainless = "0.1.4"

--- a/src/context.rs
+++ b/src/context.rs
@@ -81,6 +81,7 @@ impl Context {
 }
 
 
+#[cfg(test)]
 describe! context {
 
     before_each {

--- a/src/events.rs
+++ b/src/events.rs
@@ -27,6 +27,7 @@ impl EventData {
 pub type EventSender = mio::Sender<EventData>;
 
 
+#[cfg(test)]
 describe! event_data {
     it "AdapterStart should return its name as a description" {
         let data = EventData::AdapterStart { name: "name".to_owned() };

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,8 +15,8 @@
 #![plugin(clippy)]
 #![deny(clippy)]
 
-#![feature(const_fn)] // Dependency of stainless
-#![plugin(stainless)] // Test runner
+#![cfg_attr(test, feature(const_fn))] // Dependency of stainless
+#![cfg_attr(test, plugin(stainless))] // Test runner
 
 extern crate core;
 extern crate docopt;

--- a/src/service.rs
+++ b/src/service.rs
@@ -40,6 +40,7 @@ pub trait ServiceAdapter {
 }
 
 
+#[cfg(test)]
 describe! service {
     before_each {
         extern crate serde_json;


### PR DESCRIPTION
- stainless in now under [dev-dependencies]
- the plugin is included only when cfg=test
- and so do the tests
