### PR TITLE
following convention for generic parameter type

### DIFF
--- a/src/http_server.rs
+++ b/src/http_server.rs
@@ -12,12 +12,12 @@ use std::path::Path;
 use std::thread;
 use core::marker::Reflect;
 
-pub struct HttpServer<Ctx> where Ctx: ContextTrait {
-    context: Shared<Ctx>,
+pub struct HttpServer<T> {
+    context: Shared<T>,
 }
 
-impl<Ctx> HttpServer<Ctx> where Ctx: Send + Reflect + ContextTrait + 'static {
-    pub fn new(context: Shared<Ctx>) -> HttpServer<Ctx> {
+impl<T> HttpServer<T> where T: Send + Reflect + ContextTrait + 'static {
+    pub fn new(context: Shared<T>) -> HttpServer<T> {
         HttpServer { context: context }
     }
 

--- a/src/service_router.rs
+++ b/src/service_router.rs
@@ -10,7 +10,7 @@ use router::Router;
 use core::marker::Reflect;
 
 
-pub fn create<Ctx: Send + Reflect + ContextTrait + 'static> (context: Shared<Ctx>) -> Router {
+pub fn create<T: Send + Reflect + ContextTrait + 'static> (context: Shared<T>) -> Router {
 
     let mut router = Router::new();
     let context1 = context.clone();


### PR DESCRIPTION
Minor syntax change.

>  Convention says that the first generic parameter should be T, for ‘type’

Source: https://doc.rust-lang.org/book/generics.html
