### PR TITLE
Add a generic process manager and some basic setup for the ngrok process

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11,6 +11,7 @@ dependencies = [
  "hyper 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "iron 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "iron-test 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "mio 0.5.0 (git+https://github.com/carllerche/mio.git)",
  "mount 0.0.10 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -27,7 +28,7 @@ dependencies = [
 
 [[package]]
 name = "aho-corasick"
-version = "0.4.1"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "memchr 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -73,7 +74,7 @@ name = "clippy"
 version = "0.0.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "regex-syntax 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex-syntax 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "semver 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-normalization 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -102,7 +103,7 @@ name = "docopt"
 version = "0.6.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "regex 0.1.48 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 0.1.51 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "strsim 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -121,7 +122,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "log 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex 0.1.48 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 0.1.51 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -148,7 +149,7 @@ dependencies = [
 
 [[package]]
 name = "gcc"
-version = "0.3.23"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -407,7 +408,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "num"
-version = "0.1.30"
+version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "rand 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -430,7 +431,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bitflags 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "gcc 0.3.23 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gcc 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "openssl-sys 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -454,7 +455,7 @@ name = "openssl-sys-extras"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "gcc 0.3.23 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gcc 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "openssl-sys 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -511,17 +512,18 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "0.1.48"
+version = "0.1.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "aho-corasick 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "aho-corasick 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "memchr 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex-syntax 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex-syntax 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "utf8-ranges 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "regex-syntax"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -554,7 +556,7 @@ name = "rust-crypto"
 version = "0.2.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "gcc 0.3.23 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gcc 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.18 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -597,7 +599,7 @@ name = "serde"
 version = "0.6.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "num 0.1.30 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num 0.1.31 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -615,7 +617,7 @@ name = "serde_json"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "num 0.1.30 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num 0.1.31 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -761,6 +763,11 @@ dependencies = [
  "winapi 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "utf8-ranges"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "uuid"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ get_if_addrs = "0.3.1"
 hyper = "0.7.2"
 iron = "0.2.6"
 iron-test = "0.2.0"
+libc = "0.2.7"
 log = "0.3"
 mio = { git = "https://github.com/carllerche/mio.git" }
 mount = "0.0.10"

--- a/src/context.rs
+++ b/src/context.rs
@@ -12,6 +12,7 @@ use std::io::Error;
 use std::net::SocketAddr;
 use std::net::ToSocketAddrs;
 use std::sync::{ Arc, Mutex };
+use tunnel_controller:: { TunnelConfig, Tunnel };
 use ws;
 
 // The `global` context available to all.
@@ -21,6 +22,7 @@ pub struct Context {
     pub http_port: u16,
     pub ws_port: u16,
     services: HashMap<String, Box<Service>>,
+    tunnel: Option<Tunnel>,
     websockets: HashMap<ws::util::Token, ws::Sender>,
 }
 
@@ -30,10 +32,11 @@ const DEFAULT_HOSTNAME: &'static str = "::"; // ipv6 default.
 
 pub trait ContextTrait {
     fn new(verbose: bool, hostname: Option<String>,
-           http_port: Option<u16>, ws_port: Option<u16>) -> Self;
+           http_port: Option<u16>, ws_port: Option<u16>,
+           tunnel_host: Option<String>) -> Self;
     fn shared(verbose: bool, hostname: Option<String>,
-              http_port: Option<u16>,
-              ws_port: Option<u16>) -> Shared<Self>;
+              http_port: Option<u16>, ws_port: Option<u16>,
+              tunnel_host: Option<String>) -> Shared<Self>;
     fn add_service(&mut self, service: Box<Service>);
     fn remove_service(&mut self, id: String);
     fn add_websocket(&mut self, socket_out: ws::Sender);
@@ -45,6 +48,8 @@ pub trait ContextTrait {
     fn get_http_root_for_service(&self, service_id: String) -> String;
     fn get_ws_root_for_service(&self, service_id: String) -> String;
     fn http_as_addrs(&self) -> Result<IntoIter<SocketAddr>, Error>;
+    fn start_tunnel(&mut self) -> Result<(), Error>;
+    fn stop_tunnel(&mut self) -> Result<(), Error>;
 }
 
 pub type Shared<T> = Arc<Mutex<T>>;
@@ -52,20 +57,30 @@ pub type SharedContext = Shared<Context>;
 
 impl ContextTrait for Context {
     fn new(verbose: bool, hostname: Option<String>,
-               http_port: Option<u16>, ws_port: Option<u16>) -> Self {
+               http_port: Option<u16>, ws_port: Option<u16>,
+               tunnel_host: Option<String>) -> Self {
+
+        let http_port = http_port.unwrap_or(DEFAULT_HTTP_PORT);
+
+        let tunnel = if let Some(host) = tunnel_host {
+            Some(Tunnel::new(TunnelConfig::new(http_port, host)))
+        } else {
+            None
+        };
 
         Context { services: HashMap::new(),
                   websockets: HashMap::new(),
+                  tunnel: tunnel,
                   verbose: verbose,
                   hostname:  hostname.unwrap_or(DEFAULT_HOSTNAME.to_owned()),
-                  http_port: http_port.unwrap_or(DEFAULT_HTTP_PORT),
+                  http_port: http_port,
                   ws_port: ws_port.unwrap_or(DEFAULT_WS_PORT) }
     }
 
     fn shared(verbose: bool, hostname: Option<String>,
-                  http_port: Option<u16>,
-                  ws_port: Option<u16>) -> Shared<Self> {
-        Arc::new(Mutex::new(Context::new(verbose, hostname, http_port, ws_port)))
+                  http_port: Option<u16>, ws_port: Option<u16>,
+                  tunnel_host: Option<String>) -> SharedContext {
+        Arc::new(Mutex::new(Context::new(verbose, hostname, http_port, ws_port, tunnel_host)))
     }
 
     fn add_service(&mut self, service: Box<Service>) {
@@ -112,6 +127,21 @@ impl ContextTrait for Context {
     fn http_as_addrs(&self) -> Result<IntoIter<SocketAddr>, Error> {
         (self.hostname.as_str(), self.http_port).to_socket_addrs()
     }
+
+    fn start_tunnel(&mut self) -> Result<(), Error> {
+        match self.tunnel {
+            Some(ref mut tunnel) => tunnel.start(),
+            // If nothing is configured, just allow
+            _ => Ok(())
+        }
+    }
+
+    fn stop_tunnel(&mut self) -> Result<(), Error> {
+        match self.tunnel {
+            None => Ok(()),
+            Some(ref mut tunnel) => tunnel.stop(),
+        }
+    }
 }
 
 
@@ -122,7 +152,7 @@ describe! context {
         use stubs::service::ServiceStub;
 
         let service = ServiceStub;
-        let context = Context::shared(false, Some("localhost".to_owned()), None, None);
+        let context = Context::shared(false, Some("localhost".to_owned()), None, None, None);
         let mut locked_context = context.lock().unwrap();
     }
 

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -44,6 +44,11 @@ impl Controller {
         // Start the dummy adapter.
         let dummy_adapter = DummyAdapter::new(self.sender.clone(), self.context.clone());
         dummy_adapter.start();
+
+        {
+            let mut context = self.context.lock().unwrap();
+            context.start_tunnel().unwrap();
+        }
     }
 }
 

--- a/src/managed_process.rs
+++ b/src/managed_process.rs
@@ -1,0 +1,252 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// Assumes Unix
+use libc::{self,  c_int};
+
+use std::thread;
+use std::thread::JoinHandle;
+use std::sync::{ Arc, Mutex };
+use std::process::Child;
+use std::io::{ Error, ErrorKind, Result };
+use std::time::{ SystemTime, Duration, UNIX_EPOCH };
+
+/// Unix exit statuses
+#[derive(PartialEq, Eq, Clone, Copy, Debug)]
+pub struct ExitStatus(c_int);
+
+const RESTART_TIME_THRESHOLD: f64 = 5.0; // seconds
+
+fn seconds_since_epoch() -> f64 {
+    let now = SystemTime::now();
+    now.duration_from_earlier(UNIX_EPOCH).unwrap().as_secs() as f64
+}
+
+pub struct ManagedProcess {
+    kill_signal: Arc<Mutex<u32>>,
+    pid:         Arc<Mutex<Option<u32>>>,
+    thread:      JoinHandle<()>
+}
+
+impl ManagedProcess {
+
+    /// Create a new ManagedProcess and start it.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tunnel_controller::ManagedProcess;
+    /// use std::process::Command;
+    ///
+    /// let process = ManagedProcess::start(|| {
+    ///     Command::new("echo")
+    ///             .arg("Hello")
+    ///             .arg("World")
+    ///             .spawn()
+    /// });
+    ///
+    /// ```
+    pub fn start<F: 'static>(spawn: F) -> Result<ManagedProcess>
+        where F: Fn() -> Result<Child> + Send {
+
+        let pid = Arc::new(Mutex::new(None));
+
+        // Uses a u32 Mutex to avoid the compiler complaining that you can use an AtomicBool.
+        // In this case we want a bool like thing _and_ a lock.
+        let kill_signal = Arc::new(Mutex::new(0));
+
+        let shared_kill_signal  = kill_signal.clone();
+        let shared_pid = pid.clone();
+
+        let thread = thread::spawn(move || {
+            // Artificial start/end time for first run
+            let mut start_time = RESTART_TIME_THRESHOLD as f64;
+            let mut end_time = 0 as f64;
+            let mut backoff = 0;
+            let mut starts = 0;
+
+            loop {
+                let mut child_process;
+
+                {
+                    let kill_signal = shared_kill_signal.lock().unwrap();
+                    let mut pid = shared_pid.lock().unwrap();
+
+                    if *kill_signal == 1 {
+                        *pid = None;
+                        debug!("Received process kill signal");
+                        break;
+                    }
+
+                    if (end_time - start_time) < RESTART_TIME_THRESHOLD {
+                       backoff += 1;
+                       let backoff_seconds = (backoff * backoff) / 2;
+                       info!("Backing off creating a new process for {} seconds", backoff_seconds);
+                       thread::sleep(Duration::new(backoff_seconds, 0));
+                    } else {
+                        backoff = 0;
+                    }
+
+                    info!("Starting process. Restarted {} times", starts);
+                    start_time = seconds_since_epoch();
+                    child_process = spawn().unwrap();
+                    *pid = Some(child_process.id());
+                }
+
+                starts += 1;
+
+                info!("Started managed process pid: {}", child_process.id());
+                child_process.wait().unwrap();
+                end_time = seconds_since_epoch();
+            }
+        });
+
+        Ok(ManagedProcess {
+            kill_signal: kill_signal,
+            pid:  pid,
+            thread: thread
+        })
+    }
+
+    /// Get the current process ID or None if no process is running
+    fn get_pid(&self) -> Option<u32> {
+        *self.pid.lock().unwrap()
+    }
+
+    /// Shut the ManagedProcess down safely. Equivalent to sending SIGKILL to the
+    /// running process if it is currently alive
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tunnel_controller::ManagedProcess;
+    /// use std::process::Command;
+    ///
+    /// let process = ManagedProcess::start(|| {
+    ///     Command::new("sleep")
+    ///             .arg("10000")
+    ///             .spawn()
+    /// });
+    ///
+    /// process.shutdown().unwrap();
+    ///
+    /// ```
+    pub fn shutdown(self) -> Result<()> {
+
+        {
+            let mut kill_signal = self.kill_signal.lock().unwrap();
+            *kill_signal = 1;
+        }
+
+        // If there is no assigned pid, the process is not running.
+        let pid = self.get_pid();
+
+        if pid.is_none() {
+            self.join_thread();
+            return Ok(());
+        }
+
+        let pid = pid.unwrap() as i32;
+
+        // if the process has finished, and therefore had waitpid called,
+        // and we kill it, then on unix we might ending up killing a
+        // newer process that happens to have a re-used id
+        let status = try_wait(pid);
+
+        if status.is_some() {
+            // Process is already exited
+            self.join_thread();
+            return Ok(());
+        }
+
+        debug!("Sending SIGKILL to pid: {}", pid);
+        unsafe { try!(c_rv(libc::kill(pid, libc::SIGKILL))); }
+
+        self.join_thread();
+        Ok(())
+    }
+
+    /// Wait for the thread to exit
+    fn join_thread(self) -> () {
+        self.thread.join().unwrap();
+    }
+}
+
+
+/// A non-blocking 'wait' for a given process id.
+fn try_wait(id: i32) -> Option<ExitStatus> {
+    let mut status = 0 as c_int;
+
+    match c_rv_retry(|| unsafe {
+        libc::waitpid(id, &mut status, libc::WNOHANG)
+    }) {
+        Ok(0)  => None,
+        Ok(n) if n == id => Some(ExitStatus(status)),
+        Ok(n)  => panic!("Unknown pid: {}", n),
+        Err(e) => panic!("Unknown waitpid error: {}", e)
+    }
+}
+
+/// Check the return value of libc function and turn it into a
+/// Result type
+fn c_rv(t: c_int) -> Result<c_int> {
+    if t == -1 {
+        Err(Error::last_os_error())
+    } else {
+        Ok(t)
+    }
+}
+
+/// Check the return value of a libc function, but, retry the given function if
+/// the returned error is EINTR (Interrupted)
+fn c_rv_retry<F>(mut f: F) -> Result<c_int>
+    where F: FnMut() -> c_int
+{
+    loop {
+        match c_rv(f()) {
+            Err(ref e) if e.kind() == ErrorKind::Interrupted => {}
+            other => return other,
+        }
+    }
+}
+
+#[test]
+fn test_managed_process_restart() {
+    use std::sync::mpsc::channel;
+    use std::process::Command;
+
+    let (counter_tx, counter_rx) = channel();
+
+    let process = ManagedProcess::start(move || {
+        counter_tx.send(1).unwrap();
+
+        Command::new("sleep")
+                .arg("0")
+                .spawn()
+    }).unwrap();
+
+    let mut count = 0;
+
+    // Maybe spin with try_recv and check a duration
+    // to assert liveness?
+    while count < 2 {
+        count = count + counter_rx.recv().unwrap()
+    }
+
+    process.shutdown().unwrap();
+}
+
+#[test]
+fn test_managed_process_shutdown() {
+    use std::process::Command;
+    // Ideally need a timeout. The test should be, if shutdown doesn't happen immediately,
+    // something's broken.
+    let process = ManagedProcess::start(|| {
+        Command::new("sleep")
+                .arg("1000")
+                .spawn()
+    }).unwrap();
+
+    process.shutdown().unwrap();
+}

--- a/src/stubs/context.rs
+++ b/src/stubs/context.rs
@@ -25,7 +25,9 @@ pub type SharedContextStub = Arc<Mutex<ContextStub>>;
 
 impl ContextTrait for ContextStub {
 
-    fn new(verbose: bool, hostname: Option<String>, http_port: Option<u16>, ws_port: Option<u16>)
+    fn new(verbose: bool, hostname: Option<String>,
+           http_port: Option<u16>, ws_port: Option<u16>,
+           tunnel_host: Option<String>)
            -> ContextStub {
         ContextStub {
             websockets: HashMap::new(),
@@ -33,9 +35,10 @@ impl ContextTrait for ContextStub {
         }
     }
 
-    fn shared(verbose: bool, hostname: Option<String>, http_port: Option<u16>,
-              ws_port: Option<u16>) -> SharedContextStub {
-        Arc::new(Mutex::new(ContextStub::new(verbose, hostname, http_port, ws_port)))
+    fn shared(verbose: bool, hostname: Option<String>,
+              http_port: Option<u16>, ws_port: Option<u16>,
+              tunnel_host: Option<String>) -> SharedContextStub {
+        Arc::new(Mutex::new(ContextStub::new(verbose, hostname, http_port, ws_port, tunnel_host)))
     }
 
     fn add_service(&mut self, service: Box<Service>) {}
@@ -72,10 +75,18 @@ impl ContextTrait for ContextStub {
         Ok(vec![server].into_iter())
     }
 
+    fn start_tunnel(&mut self) -> Result<(), Error> {
+        Ok(())
+    }
+
+    fn stop_tunnel(&mut self) -> Result<(), Error> {
+        Ok(())
+    }
+
 }
 
 impl ContextStub {
     pub fn blank_shared() -> SharedContextStub {
-        ContextStub::shared(false, Some("".to_owned()), Some(0), Some(0))
+        ContextStub::shared(false, Some("".to_owned()), Some(0), Some(0), None)
     }
 }

--- a/src/tunnel_controller.rs
+++ b/src/tunnel_controller.rs
@@ -1,0 +1,90 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// Assumes Unix
+use std::io::prelude::*;
+use std::fs::File;
+use std::process::{ Child, Command };
+use std::io::Result;
+use managed_process::ManagedProcess;
+
+pub type TunnelProcess = ManagedProcess;
+
+pub struct Tunnel {
+    config: TunnelConfig,
+    pub tunnel_process: Option<TunnelProcess>
+}
+
+#[derive(Clone, Debug)]
+pub struct TunnelConfig {
+    local_port: u16,
+    remote_host: String,
+}
+
+impl TunnelConfig {
+    pub fn new(port: u16, remote_host: String) -> Self {
+        TunnelConfig {
+            local_port: port,
+            remote_host: remote_host
+        }
+    }
+
+    /// Describes how to spawn the ngrok process
+    pub fn spawn(&self) -> Result<Child> {
+        self.write_config_file();
+        Command::new("ngrok")
+                // Important! By default ngrok has a curses like view
+                // which takes over terminal, setting log overrides that
+                .arg("-log=stdout")
+                .arg("-config")
+                .arg("ngrok_config.yaml")
+                .arg(self.local_port.to_string())
+                .spawn()
+    }
+
+    /// Write out the config file that ngrok relies on - this means that this file will always be
+    /// around in the right place, it doesn't clean up after itself
+    fn write_config_file(&self) -> () {
+        let mut file = File::create("ngrok_config.yaml").unwrap();
+        let remote_host = self.remote_host.to_owned();
+
+        file.write_fmt(format_args!("server_addr: {}\ntrust_host_root_certs: false", remote_host)).unwrap();
+    }
+}
+
+impl Tunnel {
+
+    /// Create a new Tunnel object containing the necessary
+    /// configuration
+    pub fn new(config: TunnelConfig) -> Tunnel {
+        Tunnel {
+            config: config,
+            tunnel_process: None
+        }
+    }
+
+    /// Start the Tunnel process if it has not already been started
+    pub fn start(&mut self) -> Result<()> {
+        if let Some(_) = self.tunnel_process {
+            // Already started
+            Ok(())
+        } else {
+            let tunnel_config = self.config.clone();
+
+            self.tunnel_process = Some(ManagedProcess::start(move || {
+                tunnel_config.spawn()
+            }).unwrap());
+
+            Ok(())
+        }
+    }
+
+    /// Stop the tunnel process if it is runnnig
+    pub fn stop(&mut self) -> Result<()> {
+        match self.tunnel_process.take() {
+            None => Ok(()),
+            Some(process) => process.shutdown()
+        }
+    }
+}


### PR DESCRIPTION
This requires `ngrok` in the `$PATH`. 

I just wanted to get some eyes on this - next I need to add `timebomb` to the tests and look at standing up some integration tests. 

If you want to try it, this should work with the free ngrok service :).

Couple of things I'm unsure about at this moment:  
1. Managing the process in the 'context', it seems to make sense at the moment. 
2. Also proxying the web socket connection.
3. Turning on/off the tunnel via the HTTP API.
