### PR TITLE
Fix build on rust-nightly: bump dependencies where appropriate.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 sudo: false
 language: rust
 rust:
-    - nightly-2016-02-13
+    - nightly-2016-02-22
 cache:
     directories:
         - $HOME/.cargo

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2,7 +2,7 @@
 name = "foxbox"
 version = "0.1.0"
 dependencies = [
- "clippy 0.0.41 (registry+https://github.com/rust-lang/crates.io-index)",
+ "clippy 0.0.44 (registry+https://github.com/rust-lang/crates.io-index)",
  "docopt 0.6.78 (registry+https://github.com/rust-lang/crates.io-index)",
  "docopt_macros 0.6.81 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -19,11 +19,11 @@ dependencies = [
  "rustc-serialize 0.3.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_macros 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_macros 0.6.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "stainless 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "staticfile 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
- "ws 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ws 0.4.5 (git+https://github.com/housleyjk/ws-rs.git?rev=d154fc5)",
 ]
 
 [[package]]
@@ -36,7 +36,7 @@ dependencies = [
 
 [[package]]
 name = "aster"
-version = "0.12.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -71,7 +71,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "clippy"
-version = "0.0.41"
+version = "0.0.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "regex-syntax 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -331,22 +331,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "mio"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "bytes 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "miow 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "net2 0.2.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "nix 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "slab 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "time 0.1.34 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "miow"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -381,15 +365,6 @@ dependencies = [
  "libc 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "ws2_32-sys 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "nix"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "bitflags 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -483,23 +458,23 @@ dependencies = [
 
 [[package]]
 name = "quasi"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "quasi_codegen"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "aster 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "aster 0.13.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "quasi_macros"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "quasi_codegen 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quasi_codegen 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -604,12 +579,12 @@ dependencies = [
 
 [[package]]
 name = "serde_codegen"
-version = "0.6.13"
+version = "0.6.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "aster 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "quasi 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "quasi_macros 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "aster 0.13.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quasi 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quasi_macros 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -623,10 +598,10 @@ dependencies = [
 
 [[package]]
 name = "serde_macros"
-version = "0.6.13"
+version = "0.6.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "serde_codegen 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_codegen 0.6.14 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -791,13 +766,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "ws"
 version = "0.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+source = "git+https://github.com/housleyjk/ws-rs.git?rev=d154fc5#d154fc56e8dd06d9172efd08ef0db9c244668cbf"
 dependencies = [
  "httparse 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "mio 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mio 0.5.0 (git+https://github.com/carllerche/mio.git)",
  "rand 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha1 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "slab 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["fabrice <fabrice@desre.org>"]
 build = "build.rs"
 
 [dependencies]
-clippy = "0.0.41"
+clippy = "0.0.44"
 docopt = "0.6.78"
 docopt_macros = "0.6.80"
 env_logger = "0.3.2"
@@ -22,10 +22,10 @@ router = "0.1.0"
 rustc-serialize = "0.3"
 serde = "0.6.13"
 serde_json = "0.6.0"
-serde_macros = "0.6.13"
+serde_macros = "0.6.14"
 staticfile = "0.1.0"
 uuid = "0.1.18"
-ws = "0.4.5"
+ws = { git = "https://github.com/housleyjk/ws-rs.git", rev = "d154fc5" }
 
 [dev-dependencies]
 stainless = "0.1.4"


### PR DESCRIPTION
Tested with rustc 1.8.0-dev (c8fc4817d 2016-02-22)

@fabricedesre r?

(I had to bump clippy too)
