### PR TITLE
Try dependency caching on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,11 @@
 language: rust
 rust:
     - nightly-2016-02-13
+cache:
+    directories:
+        - $HOME/.cargo
+        - node_modules
+        - $TRAVIS_BUILD_DIR/target
 
 before_script:
     - "sh -e /etc/init.d/xvfb start"


### PR DESCRIPTION
Wayy faster builds with this: the bottleneck really is compiling, but because we're using a fixed version of nightly it's ok to cache target. r? @fabricedesre 
