### PR TITLE
use containers on travis for faster builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+sudo: false
 language: rust
 rust:
     - nightly-2016-02-13


### PR DESCRIPTION
If we don't need `sudo` we should be able to use the container infrastructure on Travis.
https://docs.travis-ci.com/user/workers/container-based-infrastructure/
