### PR TITLE
Make tests pass.

### DIFF
--- a/src/registration.rs
+++ b/src/registration.rs
@@ -87,7 +87,8 @@ impl Registrar {
             for iface in ifaces {
                 if ! (iface.name.starts_with("eth") ||
                       iface.name.starts_with("wlan") ||
-                      iface.name.starts_with("en")) {
+                      iface.name.starts_with("en") ||
+                      iface.name.starts_with("wlp3s")) {
                     continue;
                 }
                 if let IfAddr::V4(ref v4) = iface.addr {


### PR DESCRIPTION
On my Fedora 23 laptop, wifi is wlp3s0
As per dmesg:
[    6.394537] iwlwifi 0000:03:00.0 wlp3s0: renamed from wlan0
