### PR TITLE
Serialize services as an array

### DIFF
--- a/src/controller.rs
+++ b/src/controller.rs
@@ -18,7 +18,6 @@ use self::collections::vec::IntoIter;
 use service::{ Service, ServiceAdapter, ServiceProperties };
 use std::collections::hash_map::HashMap;
 use std::io;
-use std::io::Error;
 use std::net::SocketAddr;
 use std::net::ToSocketAddrs;
 use std::sync::{ Arc, Mutex };
@@ -135,7 +134,11 @@ impl Controller for FoxBox {
 
     fn services_as_json(&self) -> Result<String, serde_json::error::Error> {
         let services = self.services.lock().unwrap();
-        serde_json::to_string(&*services)
+        let mut array: Vec<&Box<Service>> = vec!();
+        for service in services.values() {
+            array.push(service);
+        }
+        serde_json::to_string(&array)
     }
 
     fn get_http_root_for_service(&self, service_id: String) -> String {
@@ -243,7 +246,7 @@ describe! controller {
             controller.add_service(Box::new(service));
 
             match controller.services_as_json() {
-                Ok(txt) => assert_eq!(txt, "{\"1\":{\"id\":\"1\",\"name\":\"dummy service\",\"description\":\"really nothing to see\",\"http_url\":\"2\",\"ws_url\":\"3\"}}"),
+                Ok(txt) => assert_eq!(txt, "[{\"id\":\"1\",\"name\":\"dummy service\",\"description\":\"really nothing to see\",\"http_url\":\"2\",\"ws_url\":\"3\"}]"),
                 Err(err) => assert!(false, err)
             }
         }

--- a/src/service_router.rs
+++ b/src/service_router.rs
@@ -58,7 +58,7 @@ describe! service_router {
                         &service_router).unwrap();
 
         let result = response::extract_body_to_string(response);
-        assert_eq!(result, "{}");
+        assert_eq!(result, "[]");
     }
 
     it "should make service available" {


### PR DESCRIPTION
Currently the json served at /services/list.json looks like:
{"c87fb7c7b52941bb89a90f543d1b64c7":
  {"id":"c87fb7c7b52941bb89a90f543d1b64c7",
   "name":"dummy service",
    "description":"really nothing to see",
    "http_url":"http://:::3000/services/c87fb7c7b52941bb89a90f543d1b64c7/",
    "ws_url":"ws://:::4000/services/c87fb7c7b52941bb89a90f543d1b64c7/"
    },
 "d1ba3da331f3443096bb895706e141ba":
  {"id":"d1ba3da331f3443096bb895706e141ba",
   "name":"dummy service",
   "description":"really nothing to see",
   "http_url":"http://:::3000/services/d1ba3da331f3443096bb895706e141ba/",
   "ws_url":"ws://:::4000/services/d1ba3da331f3443096bb895706e141ba/"
  }
}

This is the serialization of a HashMap, but the redundancy of the `id` does not make much sense.
Instead, this patch serialize the services as an array:
[
 {"id":"909173566206421bb34bd543eff3a5d3",
   "name":"dummy service",
   "description":"really nothing to see",
   "http_url":"http://:::3000/services/909173566206421bb34bd543eff3a5d3/",
   "ws_url":"ws://:::4000/services/909173566206421bb34bd543eff3a5d3/"},
  {"id":"dd47a01284664d14aae81c738f88e1af",
   "name":"dummy service",
   "description":"really nothing to see",
   "http_url":"http://:::3000/services/dd47a01284664d14aae81c738f88e1af/",
   "ws_url":"ws://:::4000/services/dd47a01284664d14aae81c738f88e1af/"}
]
