### PR TITLE
[WIP] Local HTTPS Support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,6 @@ node_modules
 
 # Foxbox config
 foxbox.conf
+
+# Generated certs
+certs

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,4 +33,4 @@ script:
     - $TRAVIS_BUILD_DIR/tools/execute-unit-tests-with-coverage
     - jshint static/main/js/*.js static/setup/js/*.js test/selenium/*.js test/integration/lib/*.js test/integration/test/*.js
     - npm run test-integration # starts foxbox and kills it within the test script
-    - (cargo run -- -l $BOX_LOCAL_NAME -p $BOX_PORT &> /dev/null &) ; npm run test-selenium
+    - (cargo run -- -l $BOX_LOCAL_NAME -p $BOX_PORT --disable-tls &> /dev/null &) ; npm run test-selenium

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,8 +21,10 @@ dependencies = [
  "mount 0.0.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "multicast_dns 0.1.0 (git+https://github.com/fxbox/multicast-dns.git?rev=a6e4bcc)",
  "nix 0.5.1-pre (git+https://github.com/nix-rust/nix.git?rev=138080)",
+ "openssl 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "openssl-sys 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex 0.1.55 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 0.1.58 (registry+https://github.com/rust-lang/crates.io-index)",
  "router 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rust-crypto 0.2.34 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.18 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -34,7 +36,7 @@ dependencies = [
  "time 0.1.34 (registry+https://github.com/rust-lang/crates.io-index)",
  "timer 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "transformable_channels 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "unicase 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicase 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 0.5.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "ws 0.4.5 (git+https://github.com/housleyjk/ws-rs.git?rev=d154fc5)",
@@ -152,7 +154,7 @@ name = "docopt"
 version = "0.6.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "regex 0.1.55 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 0.1.58 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "strsim 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -171,7 +173,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "log 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex 0.1.55 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 0.1.58 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -223,7 +225,7 @@ dependencies = [
  "rusqlite 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rust-crypto 0.2.34 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.18 (registry+https://github.com/rust-lang/crates.io-index)",
- "unicase 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicase 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "urlencoded 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -237,7 +239,7 @@ name = "gdi32-sys"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "winapi 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -280,7 +282,7 @@ dependencies = [
  "time 0.1.34 (registry+https://github.com/rust-lang/crates.io-index)",
  "traitobject 0.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "typeable 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "unicase 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicase 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 0.5.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -312,7 +314,7 @@ version = "0.1.0"
 source = "git+https://github.com/fxbox/iron-cors.git?rev=137d42f#137d42f86524f1a16873eba1c308cfa2a45b0bd9"
 dependencies = [
  "iron 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "unicase 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicase 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -341,7 +343,7 @@ name = "kernel32-sys"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "winapi 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -421,11 +423,11 @@ dependencies = [
  "libc 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "miow 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "net2 0.2.22 (registry+https://github.com/rust-lang/crates.io-index)",
+ "net2 0.2.23 (registry+https://github.com/rust-lang/crates.io-index)",
  "nix 0.5.0-pre (git+https://github.com/carllerche/nix-rust?rev=c4257f8a76)",
  "slab 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.34 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -434,8 +436,8 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "kernel32-sys 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "net2 0.2.22 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "net2 0.2.23 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "ws2_32-sys 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -464,13 +466,13 @@ dependencies = [
 
 [[package]]
 name = "net2"
-version = "0.2.22"
+version = "0.2.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cfg-if 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "kernel32-sys 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "ws2_32-sys 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -625,18 +627,23 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "0.1.55"
+version = "0.1.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "aho-corasick 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "memchr 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex-syntax 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex-syntax 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "utf8-ranges 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "regex-syntax"
 version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "regex-syntax"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -827,7 +834,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "kernel32-sys 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -868,7 +875,7 @@ dependencies = [
 
 [[package]]
 name = "unicase"
-version = "1.3.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "rustc_version 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -941,7 +948,7 @@ name = "user32-sys"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "winapi 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -966,7 +973,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "winapi"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -993,7 +1000,7 @@ name = "ws2_32-sys"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "winapi 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,13 +20,14 @@ foxbox_users = { git = "https://github.com/fxbox/users.git", rev = "3db32f0" }
 get_if_addrs = "0.3.1"
 hyper = "0.7.2"
 multicast_dns = { git = "https://github.com/fxbox/multicast-dns.git", rev = "a6e4bcc" }
-iron = "0.2.6"
 iron-cors = { git = "https://github.com/fxbox/iron-cors.git", rev = "137d42f" }
 libc = "0.2.7"
 log = "0.3"
 mio = { git = "https://github.com/carllerche/mio.git" }
 mount = "0.0.10"
 nix = { git = "https://github.com/nix-rust/nix.git", rev = "138080" } # Until 0.5.1 is released
+openssl = "0.7.6"
+openssl-sys = "0.7.6"
 router = "0.1.0"
 rust-crypto = "0.2.34"
 rustc-serialize = "0.3"
@@ -39,9 +40,14 @@ unicase = "1.3.0"
 time = "0.1"
 timer = "0.1.6"
 uuid = "0.1.18"
-url = "0.5.5"
+url = "0.5.7"
 ws = { git = "https://github.com/housleyjk/ws-rs.git", rev = "d154fc5" }
 xml-rs = "0.3.0"
+
+[dependencies.iron]
+version = "0.2.6"
+default-features = true
+features = ["ssl"]
 
 [dev-dependencies]
 stainless = "0.1.4"

--- a/src/service_router.rs
+++ b/src/service_router.rs
@@ -68,8 +68,9 @@ describe! service_router {
         use iron::Headers;
         use iron_test::request;
         use mount::Mount;
+        use tls::TlsOption;
 
-        let controller = FoxBox::new(false, Some("localhost".to_owned()), 1234, 5678);
+        let controller = FoxBox::new(false, Some("localhost".to_owned()), 1234, 5678, TlsOption::Disabled);
         let service_router = create(controller.clone());
 
         let mut mount = Mount::new();

--- a/src/stubs/controller.rs
+++ b/src/stubs/controller.rs
@@ -19,6 +19,7 @@ use std::net::SocketAddr;
 use std::net::ToSocketAddrs;
 use std::sync::Arc;
 use std::sync::atomic::AtomicBool;
+use tls::CertificateManager;
 use upnp::UpnpManager;
 use ws;
 
@@ -84,5 +85,12 @@ impl Controller for ControllerStub {
     }
     fn get_profile(&self) -> &ProfileService {
         &self.profile_service
+    }
+    fn get_tls_enabled(&self) -> bool {
+        false
+    }
+
+    fn get_certificate_manager(&self) -> CertificateManager {
+       CertificateManager::new()
     }
 }

--- a/src/tls/certificate_manager.rs
+++ b/src/tls/certificate_manager.rs
@@ -1,0 +1,232 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use std::collections::HashMap;
+use std::fs::{ self };
+use std::io::{ Error, ErrorKind };
+use std::path::PathBuf;
+use std::sync::{ Arc, Mutex, RwLock };
+
+use tls::certificate_record::CertificateRecord;
+use tls::ssl_context::SslContextProvider;
+
+#[derive(Clone)]
+pub struct CertificateManager {
+    ssl_hosts: Arc<RwLock<HashMap<String, CertificateRecord>>>,
+
+    // Observer
+    context_provider: Option<Arc<Mutex<Box<SslContextProvider>>>>
+}
+
+fn create_records_from_directory(path: &PathBuf) -> Result<HashMap<String, CertificateRecord>, Error> {
+    let mut records = HashMap::new();
+
+    if try!(fs::metadata(path)).is_dir() {
+        for entry in try!(fs::read_dir(path)) {
+            let entry = try!(entry);
+
+            let hostname = entry.file_name().into_string().unwrap();
+            info!("Using certificate for host {}", hostname);
+
+            let mut host_path = path.clone();
+            host_path.push(hostname.clone());
+
+            let mut cert_path = host_path.clone();
+            cert_path.push("crt.pem");
+
+            let mut private_key_file = host_path.clone();
+            private_key_file.push("private_key.pem");
+
+            records.insert(hostname.clone(), CertificateRecord {
+                hostname: hostname,
+                private_key_file: private_key_file,
+                cert_file: cert_path
+            });
+        }
+
+        info!("Loaded certificates from directory: {:?}", path);
+
+        Ok(records)
+    } else {
+        Err(Error::new(
+            ErrorKind::InvalidInput,
+            "The configured SSL certificate directory is not recognised as a directory."
+        ))
+    }
+}
+
+impl CertificateManager {
+    pub fn new() -> CertificateManager {
+        CertificateManager {
+            ssl_hosts: Arc::new(RwLock::new(HashMap::new())),
+            context_provider: None,
+        }
+    }
+
+    pub fn set_context_provider(&mut self, context_provider: Arc<Mutex<Box<SslContextProvider>>>) {
+        if self.context_provider.is_none() {
+           self.context_provider = Some(context_provider);
+           self.notify_provider();
+        } else {
+            error!("SslContextProvider was set more than once in the CertificateManager");
+        }
+    }
+
+    pub fn reload_from_directory(&mut self, directory: PathBuf) -> Result<(), Error> {
+        let certificates =  try!(create_records_from_directory(&directory));
+        {
+            let mut current_hosts = checklock!(self.ssl_hosts.write());
+            current_hosts.clear();
+            current_hosts.extend(certificates);
+        }
+
+        self.notify_provider();
+        Ok(())
+    }
+
+    #[allow(dead_code)]
+    pub fn add_certificate(&mut self, certificate_record: CertificateRecord) {
+        {
+            checklock!(self.ssl_hosts.write())
+                .insert(certificate_record.hostname.clone(), certificate_record);
+        }
+
+        self.notify_provider();
+    }
+
+    #[allow(dead_code)]
+    pub fn get_certificate(&self, hostname: String) -> Option<CertificateRecord> {
+        let ssl_hosts = checklock!(self.ssl_hosts.read());
+        let cert_record = ssl_hosts.get(&hostname);
+
+        if let Some(record) = cert_record {
+            Some(record.clone())
+        } else {
+            None
+        }
+    }
+
+    #[allow(dead_code)]
+    pub fn remove_certificate(&mut self, hostname: String) {
+        {
+            checklock!(self.ssl_hosts.write()).remove(&hostname);
+        }
+
+        self.notify_provider();
+    }
+
+    fn notify_provider(&mut self) {
+        let ssl_hosts = checklock!(self.ssl_hosts.read()).clone();
+
+        if let Some(ref mut context_provider) = self.context_provider {
+            context_provider.lock().unwrap().update(ssl_hosts);
+        }
+    }
+}
+
+
+#[cfg(test)]
+mod certificate_manager {
+    use openssl::ssl::{ SslContext, SslMethod };
+    use std::collections::HashMap;
+    use std::io::{ Error, ErrorKind };
+    use std::path::PathBuf;
+    use std::sync::{ Arc, Mutex };
+    use std::sync::mpsc::{ channel, Sender };
+    use tls::{ CertificateRecord, SslContextProvider };
+
+    use super::*;
+
+    pub struct TestSslContextProvider {
+        update_called: Sender<bool>
+    }
+
+    impl TestSslContextProvider {
+        fn new(update_chan: Sender<bool>) -> Self {
+            TestSslContextProvider {
+                update_called: update_chan
+            }
+        }
+    }
+
+    impl SslContextProvider for TestSslContextProvider {
+        fn context(&self) -> Result<SslContext, Error> {
+            SslContext::new(SslMethod::Sslv23).map_err(|_| {
+                Error::new(ErrorKind::InvalidInput, "An SSL certificate could not be configured")
+            })
+        }
+
+        fn update(&mut self, _: HashMap<String, CertificateRecord>) -> () {
+            self.update_called.send(true).unwrap();
+        }
+    }
+
+    fn test_cert_record() -> CertificateRecord {
+        CertificateRecord {
+            hostname: "test.example.com".to_owned(),
+            private_key_file: PathBuf::from("/test/key.pem"),
+            cert_file:        PathBuf::from("/test/crt.pem")
+        }
+    }
+
+    #[test]
+    fn should_allow_certificates_to_be_added() {
+        let cert_record = test_cert_record();
+        let mut cert_manager = CertificateManager::new();
+
+        cert_manager.add_certificate(cert_record.clone());
+
+        assert!(cert_manager.get_certificate("test.example.com".to_owned()).unwrap() == cert_record);
+
+        cert_manager.remove_certificate("test.example.com".to_owned());
+
+        assert!(cert_manager.get_certificate("test.example.com".to_owned()).is_none());
+    }
+
+    #[test]
+    fn should_allow_certificates_to_be_removed() {
+        let cert_record = test_cert_record();
+        let mut cert_manager = CertificateManager::new();
+
+        cert_manager.add_certificate(cert_record);
+
+        cert_manager.remove_certificate("test.example.com".to_owned());
+
+        assert!(cert_manager.get_certificate("test.example.com".to_owned()).is_none());
+    }
+
+    #[test]
+    fn should_update_configured_providers_when_cert_added() {
+        let cert_record = test_cert_record();
+        let (tx_update_called, rx_update_called) = channel();
+        let mut cert_manager = CertificateManager::new();
+
+        let provider_one = Box::new(TestSslContextProvider::new(tx_update_called));
+
+        cert_manager.set_context_provider(Arc::new(Mutex::new(provider_one)));
+
+        cert_manager.add_certificate(cert_record);
+
+        assert!(rx_update_called.recv().unwrap(), "Did not receive notification from handler after add");
+    }
+
+    #[test]
+    fn should_update_configured_providers_when_cert_removed() {
+        let cert_record = test_cert_record();
+        let (tx_update_called, rx_update_called) = channel();
+        let mut cert_manager = CertificateManager::new();
+
+        let provider_one = Box::new(TestSslContextProvider::new(tx_update_called));
+
+        cert_manager.set_context_provider(Arc::new(Mutex::new(provider_one)));
+
+        cert_manager.add_certificate(cert_record);
+
+        assert!(rx_update_called.recv().unwrap(), "Did not receive notification from handler after add");
+
+        cert_manager.remove_certificate(test_cert_record().hostname);
+
+        assert!(rx_update_called.recv().unwrap(), "Did not receive notification from handler after remove");
+    }
+}

--- a/src/tls/certificate_record.rs
+++ b/src/tls/certificate_record.rs
@@ -1,0 +1,17 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use std::path::PathBuf;
+
+/// Defines a certificate, including the hostname it is for,
+/// the private key file and the certificate file.
+#[derive(Clone, Debug, Hash, Eq, PartialEq)]
+pub struct CertificateRecord {
+    pub hostname: String,
+    pub private_key_file: PathBuf,
+    pub cert_file: PathBuf,
+    // TODO: We should probably keep a hash of the
+    // file contents as part of the CertRecord.
+    // See: https://github.com/fxbox/foxbox/issues/224
+}

--- a/src/tls/https_server_factory.rs
+++ b/src/tls/https_server_factory.rs
@@ -1,0 +1,44 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use hyper::error::Error as HyperError;
+use hyper::net::{ HttpsListener, Openssl, Ssl };
+use hyper::server::Server;
+use iron::{ Protocol, ServerFactory };
+use std::net::SocketAddr;
+use std::sync::{ Arc, Mutex };
+use tls::certificate_manager::CertificateManager;
+use tls::ssl_context::{ SniSslContextProvider, SslContextProvider };
+
+pub struct SniServerFactory<S: Ssl + Clone + Send> {
+    ssl: S
+}
+
+impl SniServerFactory<Openssl> {
+    pub fn new(ssl: &mut CertificateManager) -> Self {
+        let context_provider: Box<SslContextProvider> = Box::new(SniSslContextProvider::new());
+
+        let shared_context_provider = Arc::new(Mutex::new(context_provider));
+
+        ssl.set_context_provider(shared_context_provider.clone());
+
+        let data = shared_context_provider.lock().unwrap();
+
+        SniServerFactory {
+            ssl: Openssl {
+                context: Arc::new(data.context().unwrap())
+            }
+        }
+    }
+}
+
+impl ServerFactory<HttpsListener<Openssl>> for SniServerFactory<Openssl> {
+    fn protocol(&self) -> Protocol {
+        Protocol::Https
+    }
+
+    fn create_server(&self, sock_addr: SocketAddr) -> Result<Server<HttpsListener<Openssl>>, HyperError> {
+        Server::https(sock_addr, self.ssl.clone())
+    }
+}

--- a/src/tls/mod.rs
+++ b/src/tls/mod.rs
@@ -1,0 +1,29 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+macro_rules! checklock (
+    ($e: expr) => {
+        match $e {
+            Ok(guard) => guard,
+            Err(poisoned) => poisoned.into_inner(),
+        }
+    }
+);
+
+mod certificate_manager;
+mod certificate_record;
+mod https_server_factory;
+mod ssl_context;
+
+pub use tls::certificate_manager::*;
+pub use tls::certificate_record::*;
+pub use tls::https_server_factory::*;
+pub use tls::ssl_context::*;
+
+
+#[derive(Clone, Eq, PartialEq)]
+pub enum TlsOption {
+    Enabled,
+    Disabled,
+}

--- a/src/tls/ssl_context.rs
+++ b/src/tls/ssl_context.rs
@@ -1,0 +1,177 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use openssl::ssl::{ Ssl, SslContext, SslMethod, SSL_VERIFY_NONE };
+use openssl::ssl::error::SslError;
+use openssl::x509::X509FileType;
+use openssl_sys;
+
+use std::collections::HashMap;
+use std::io::Error;
+use std::path::Path;
+use std::sync::{ Arc, RwLock };
+
+use tls::certificate_record::CertificateRecord;
+
+pub trait SslContextProvider : Send  {
+    fn context(&self) -> Result<SslContext, Error>;
+    fn update(&mut self, HashMap<String, CertificateRecord>) -> ();
+}
+
+#[derive(Clone)]
+pub struct SniSslContextProvider {
+    main_context: Arc<RwLock<SslContext>>
+}
+
+impl SslContextProvider for SniSslContextProvider {
+    fn context(&self) -> Result<SslContext, Error> {
+        Ok(checklock!(self.main_context.read()).clone())
+    }
+
+    fn update(&mut self, configured_hosts: HashMap<String, CertificateRecord>) -> () {
+        debug!("Updating SniSslContextProvider");
+
+        let mut new_ssl_hosts = HashMap::new();
+
+        for record in configured_hosts.values() {
+            debug!("Creating SslContext for {}", record.hostname);
+            let ssl_context = create_ssl_context(&record.cert_file, &record.private_key_file);
+
+            if ssl_context.is_ok() {
+                let ssl_context = ssl_context.unwrap();
+                new_ssl_hosts.insert(record.hostname.clone(), ssl_context);
+            } else {
+                error!("Failed to configure SslContext for: {:?}", record);
+            }
+        }
+
+        debug!("Update certificates");
+        checklock!(self.main_context.write())
+            .set_servername_callback_with_data(SniSslContextProvider::servername_callback, new_ssl_hosts);
+    }
+}
+
+impl SniSslContextProvider {
+    pub fn new() -> Self {
+        SniSslContextProvider {
+            main_context: Arc::new(RwLock::new(SslContext::new(SslMethod::Sslv23).unwrap()))
+        }
+    }
+
+    fn servername_callback_impl<T>(ssl: &mut SslForSni<T>, configured_certs: &HashMap<String, T>) -> i32 {
+        debug!("servername_callback invoked");
+        let requested_hostname = ssl.get_hostname();
+
+        if requested_hostname.is_none() {
+            debug!("No SNI - ");
+            return openssl_sys::SSL_TLSEXT_ERR_NOACK;
+        }
+
+        let requested_hostname = requested_hostname.unwrap();
+
+        debug!("Selecting certificate for host {}", requested_hostname);
+
+        let ssl_context_for_hostname = configured_certs.get(&requested_hostname);
+
+        if let Some(ctx)= ssl_context_for_hostname {
+            ssl.set_context(ctx);
+        }
+
+        openssl_sys::SSL_TLSEXT_ERR_OK
+    }
+
+    fn servername_callback(ssl: &mut Ssl, _: &mut i32, configured_certs: &HashMap<String, SslContext>) -> i32 {
+        Self::servername_callback_impl(ssl, configured_certs)
+    }
+}
+
+pub trait SslForSni<T> {
+    fn get_hostname(&self) -> Option<String>;
+    fn set_context(&self, ctx: &T) -> Option<T>;
+}
+
+impl SslForSni<SslContext> for Ssl {
+    fn get_hostname(&self) -> Option<String> {
+        self.get_servername()
+    }
+
+    fn set_context(&self, ctx: &SslContext) -> Option<SslContext> {
+        Some(self.set_ssl_context(ctx))
+    }
+}
+
+pub fn create_ssl_context<C, K>(crt: &C, key: &K) -> Result<SslContext, SslError>
+    where C: AsRef<Path>, K: AsRef<Path> {
+
+    debug!("Creating SSL Context with Cert: {:?}, Key: {:?}", crt.as_ref().to_str(), key.as_ref().to_str());
+
+    let mut ctx = try!(SslContext::new(SslMethod::Sslv23));
+    try!(ctx.set_cipher_list("DEFAULT"));
+    try!(ctx.set_certificate_file(crt.as_ref(), X509FileType::PEM));
+    try!(ctx.set_private_key_file(key.as_ref(), X509FileType::PEM));
+    ctx.set_verify(SSL_VERIFY_NONE, None);
+
+    Ok(ctx)
+}
+
+#[cfg(test)]
+mod sni_ssl_context_provider {
+    use openssl_sys;
+    use std::collections::HashMap;
+    use std::sync::mpsc::{ channel, Sender };
+
+    use super::*;
+
+    pub struct MockSsl {
+        servername: Option<String>,
+        context_set: Option<Sender<String>>
+    }
+
+    impl SslForSni<String> for MockSsl {
+        fn get_hostname(&self) -> Option<String> {
+            self.servername.clone()
+        }
+
+        fn set_context(&self, ctx: &String) -> Option<String> {
+            if let Some(ref context_set) = self.context_set {
+                context_set.send(ctx.clone()).unwrap();
+            }
+
+            None
+        }
+    }
+
+    #[test]
+    fn should_set_context_based_on_servername() {
+        let (tx_context_called, rx_context_called) = channel();
+
+        let mut ssl = MockSsl {
+            servername: Some("test.knilxof.org".to_owned()),
+            context_set: Some(tx_context_called)
+        };
+
+        let mut contexts = HashMap::new();
+
+        contexts.insert("test.knilxof.org".to_owned(), "fake_context".to_owned());
+
+        let result = SniSslContextProvider::servername_callback_impl(&mut ssl, &contexts);
+
+        assert!(result == openssl_sys::SSL_TLSEXT_ERR_OK, "Servername callback did not return OK");
+        assert!(rx_context_called.recv().unwrap() == "fake_context",  "Set context was not called with the expected value");
+    }
+
+    #[test]
+    fn should_return_fail_code_if_servername_is_not_available() {
+        let mut ssl = MockSsl {
+            servername: None,
+            context_set: None,
+        };
+
+        let contexts = HashMap::new();
+
+        let result = SniSslContextProvider::servername_callback_impl(&mut ssl, &contexts);
+
+        assert!(result == openssl_sys::SSL_TLSEXT_ERR_NOACK, "Expected ERR_NOACK result from servername callback");
+    }
+}

--- a/tools/scripts/make-root-ca-and-certs.sh
+++ b/tools/scripts/make-root-ca-and-certs.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+
+# Taken from coolaj86's very useful nodejs-self-signed-certificate-example repo
+# (Apache licensed).
+# See https://github.com/coolaj86/nodejs-self-signed-certificate-example.
+
+FQDN=$1
+
+# make directories to work from
+mkdir -p certs/{server,client,ca,tmp}
+
+# Create your very own Root Certificate Authority
+openssl genrsa \
+  -out certs/ca/my-root-ca.key.pem \
+  2048
+
+# Self-sign your Root Certificate Authority
+# Since this is private, the details can be as bogus as you like
+openssl req \
+  -x509 \
+  -new \
+  -nodes \
+  -key certs/ca/my-root-ca.key.pem \
+  -days 1024 \
+  -out certs/ca/my-root-ca.crt.pem \
+  -subj "/C=US/ST=Utah/L=Provo/O=ACME Signing Authority Inc/CN=example.com"
+
+# Create a Device Certificate for each domain,
+# such as example.com, *.example.com, awesome.example.com
+# NOTE: You MUST match CN to the domain name or ip address you want to use
+openssl genrsa \
+  -out certs/server/${FQDN}-server.key.pem \
+  2048
+
+# Create a request from your Device, which your Root CA will sign
+openssl req -new \
+  -key certs/server/${FQDN}-server.key.pem \
+  -out certs/tmp/${FQDN}-server.csr.pem \
+  -subj "/C=US/ST=Utah/L=Provo/O=ACME Tech Inc/CN=${FQDN}"
+
+# Sign the request from Device with your Root CA
+# -CAserial certs/ca/my-root-ca.srl
+openssl x509 \
+  -req -in certs/tmp/${FQDN}-server.csr.pem \
+  -CA certs/ca/my-root-ca.crt.pem \
+  -CAkey certs/ca/my-root-ca.key.pem \
+  -CAcreateserial \
+  -out certs/server/${FQDN}-server.crt.pem \
+  -days 500
+
+# Create a public key, for funzies
+# see https://gist.github.com/coolaj86/f6f36efce2821dfb046d
+openssl rsa \
+  -in certs/server/${FQDN}-server.key.pem \
+  -pubout -out certs/client/${FQDN}-server.pub
+
+# Put things in their proper place
+rsync -a certs/ca/my-root-ca.crt.pem certs/server/
+rsync -a certs/ca/my-root-ca.crt.pem certs/client/


### PR DESCRIPTION
Configuring TLS:

Create a `certs/` directory containing your cert's private key and certificate:
The private_key and cert must be X509 files named `crt.pem` and `private_key.pem`

For example:

```
certs/
certs/test.knilxof.org/crt.pem
certs/test.knixof.org/private_key.pem
```

The directory that `certs` are found in can be configured in the configuration file under:  `foxbox.certficate_directory`, by default the software will look for the `certs` directory in your current working directory.

You can disable TLS entirely using the `--disable-tls` command line argument.
