### PR TITLE
Adding Philips Hue adapter

### DIFF
--- a/huedemo.sh
+++ b/huedemo.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+cmd=$1
+
+case $cmd in
+	status)
+		curl -s -X GET http://localhost:3000/services/list.json \
+			| tr '{' \\012 \
+			| cut -d, -f1 \
+			| tr -d \" \
+			| grep ^id \
+			| cut -d: -f2 \
+			| while read id ; do
+				echo -n "$id: "
+				curl -X GET http://localhost:3000/services/$id/state
+				echo
+			  done
+		;;
+	disco)
+		id=$2
+		curl -s -X PUT http://localhost:3000/services/$id/state -d '{"on": true}'
+		echo
+		while true ; do 
+			curl -s -X PUT http://localhost:3000/services/$id/state -d '{"hue": 0.0, "sat": 1.0, "val": 1}'
+			echo
+			sleep 2
+			curl -s -X PUT http://localhost:3000/services/$id/state -d '{"hue": 120, "sat": 1.0, "val": 1}'
+			echo
+			sleep 2
+			curl -s -X PUT http://localhost:3000/services/$id/state -d '{"hue": 240, "sat": 1.0, "val": 1}' 
+			echo
+			sleep 2
+		done
+		;;
+	*)
+		echo "usage: $0 <cmd> [<id>]"
+		echo "  cmd: status      - list status of all available lights"
+		echo "       disco <id>  - well, ... disco!"
+esac
+
+

--- a/src/adapters/mod.rs
+++ b/src/adapters/mod.rs
@@ -1,0 +1,24 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+mod philips_hue;
+
+use controller::Controller;
+use service::ServiceAdapter;
+
+pub struct AdapterManager<T> {
+    controller: T
+}
+
+impl<T: Controller> AdapterManager<T> {
+    pub fn new(controller: T) -> Self {
+        debug!("Creating Adapter Manager");
+        AdapterManager { controller: controller }
+    }
+
+    pub fn start(&self) {
+        // Start all the adapters.
+        philips_hue::PhilipsHueAdapter::new(self.controller.clone()).start();
+	}
+}

--- a/src/adapters/philips_hue/api/mod.rs
+++ b/src/adapters/philips_hue/api/mod.rs
@@ -1,0 +1,221 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#![allow(dead_code)]
+
+extern crate serde_json;
+
+pub mod structs;
+
+use adapters::philips_hue::http;
+use std;
+use std::collections::BTreeMap;
+use std::error::Error;
+use std::hash::{Hash, SipHasher, Hasher};
+
+
+#[derive(Debug, Hash)]
+struct HueHubApiToken {
+    iv: String,
+    id: String,
+}
+
+impl HueHubApiToken {
+    // This implementation offers 64 bit
+    fn as_hash(&self) -> String {
+        let mut hasher = SipHasher::new();
+        self.hash(&mut hasher);
+        format!("{:016x}", hasher.finish()).to_owned()
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct HueHubApi {
+    pub id: String,
+    pub ip: String,
+    pub token: String,
+}
+
+impl std::fmt::Display for HueHubApi {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "Hue Bridge id:{} at {:?}", self.id, self.ip)
+    }
+}
+
+impl HueHubApi {
+    pub fn new(id: String, ip: String) -> HueHubApi {
+        // TODO: Generate a unique but reproducible access token.
+        // The token must not be guessable by an outsider.
+
+        // TODO: replace with a loooong stored random string
+        let stored_random = String::from("4"); // chosen by fair dice roll.
+        let token_gen = HueHubApiToken { iv: stored_random, id: id.clone() };
+        let token = format!("foxbox-{}", token_gen.as_hash());
+        HueHubApi { id: id, ip: ip, token: token }
+    }
+
+    pub fn get(&self, cmd: String) -> Result<String, Box<Error>> {
+        let url = format!("http://{}/api/{}/{}", self.ip, self.token, cmd);
+        debug!("GET request to Philips Hue bridge {}: {}", self.id, url);
+        let content = http::get(url);
+        debug!("Philips Hue API response: {:?}", content);
+        content
+    }
+
+    pub fn post(&self, cmd: String, data: String) -> Result<String, Box<Error>> {
+        let url = format!("http://{}/api/{}/{}", self.ip, self.token, cmd);
+        debug!("POST request to Philips Hue bridge {}: {} data: {}", self.id, &url, &data);
+        let content = http::post(url, data);
+        debug!("Philips Hue API response: {:?}", content);
+        content
+    }
+
+    pub fn post_unauth(&self, cmd: String, data: String) -> Result<String, Box<Error>> {
+        let url = format!("http://{}/{}", self.ip, cmd);
+        debug!("POST request to Philips Hue bridge {}: {} data: {}", self.id, &url, &data);
+        let content = http::post(url, data);
+        debug!("Philips Hue API response: {:?}", content);
+        content
+    }
+
+    pub fn put(&self, cmd: String, data: String) -> Result<String, Box<Error>> {
+        let url = format!("http://{}/api/{}/{}", self.ip, self.token, cmd);
+        debug!("PUT request to Philips Hue bridge {}: {} data: {}", self.id, &url, &data);
+        let content = http::put(url, data);
+        debug!("Philips Hue API response: {:?}", content);
+        content
+    }
+
+    pub fn is_available(&self) -> bool {
+        let url = format!("http://{}/", self.ip);
+        let content = http::get(url);
+        match content {
+            Ok(value) => {
+                value.contains("hue personal wireless lighting")
+            },
+            Err(_) => {
+                false
+            }
+        }
+    }
+
+    pub fn get_settings(&self) -> String {
+        // [{"error":{"type":1,"address":"/","description":"unauthorized user"}}]
+        self.get("".to_owned()).unwrap_or("".to_owned()) // TODO no unwrap
+    }
+
+    pub fn is_paired(&self) -> bool {
+        let settings = self.get_settings();
+        !settings.contains("unauthorized user")
+    }
+
+    pub fn try_pairing(&self) -> bool {
+        // [{"success":{"username":"foxboxb-001788fffe25681a"}}]
+        // [{"error":{"type":101,"address":"/","description":"link button not pressed"}}]
+        let url = "api".to_owned();
+        let req = format!("{{\"username\": \"{}\", \"devicetype\": \"foxbox_hub\"}}", self.token);
+        let response = self.post_unauth(url.clone(),
+            req.clone()).unwrap_or("".to_owned()); // TODO: no unwrap
+        response.contains("success")
+    }
+
+    pub fn get_lights(&self) -> Vec<HueLight> {
+        let mut lights: Vec<HueLight> = Vec::new();
+        let url = "lights".to_owned();
+        let res = self.get(url).unwrap(); // TODO: remove unwrap
+        let json: BTreeMap<String, structs::HueHubSettingsLightEntry> = structs::parse_json(&res).unwrap(); // TODO: no unwrap
+
+        for (key,_) in json {
+            let light = HueLight::new(self.id.clone(), self.ip.clone(), key);
+            lights.push(light);
+        }
+
+        lights
+    }
+
+    pub fn get_light_status(&self, id: &String) -> structs::HueHubSettingsLightEntry {
+        let url = format!("lights/{}", id);
+        let res = self.get(url).unwrap(); // TODO: remove unwrap
+        structs::parse_json(&res).unwrap() // TODO no unwrap
+    }
+
+    pub fn set_light_color(&self, light_id: &String, hue: u32, sat: u32, val: u32, on: bool) {
+        let url = format!("lights/{}/state", light_id);
+        let cmd = format!("{{\"hue\":{}, \"sat\":{}, \"bri\":{}, \"on\": {}}}",
+            hue, sat, val, on);
+        let _ = self.put(url, cmd);
+    }
+
+}
+
+#[derive(Debug)]
+pub struct LightState {
+    pub hue: f32,
+    pub sat: f32,
+    pub val: f32,
+    pub on: bool,
+}
+
+impl LightState {
+    pub fn new(hue: f32, sat: f32, val: f32, on: bool) -> LightState {
+        LightState { hue: hue, sat: sat, val: val, on: on }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct HueLight {
+    pub hub_id: String, // TODO: move to HueHubApi reference
+    pub hub_ip: String,
+    pub hue_id: String,
+}
+
+impl HueLight {
+    pub fn new(hub_id: String, hub_ip: String, light_id: String) -> HueLight {
+        HueLight {
+            hub_id: hub_id,
+            hub_ip: hub_ip,
+            hue_id: light_id,
+        }
+    }
+
+    pub fn get_settings(&self) -> structs::HueHubSettingsLightEntry {
+        let api = HueHubApi::new(self.hub_id.clone(), self.hub_ip.clone());
+        api.get_light_status(&self.hue_id)
+    }
+
+    pub fn get_state(&self) -> LightState {
+        // TODO: Work with api reference instead of instantiating one ad-hoc.
+        // Created issues in muti-treading.
+        let api = HueHubApi::new(self.hub_id.clone(), self.hub_ip.clone());
+        let ls = api.get_light_status(&self.hue_id);
+        let hue: f32 = ls.state.hue as f32 / 65535f32 * 360f32;
+        let sat: f32 = ls.state.sat as f32 / 254f32;
+        let val: f32 = ls.state.bri as f32 / 254f32;
+        let on = ls.state.on;
+
+        LightState::new(hue, sat, val, on)
+    }
+
+    pub fn set_state(&self, state: LightState) {
+        // Ensure valid ranges
+        let hue = ((state.hue % 360f32) + 360f32) % 360f32; // [0,360)
+        let mut sat = state.sat; // [0,1]
+        if sat < 0f32 { sat = 0f32 };
+        if sat > 1f32 { sat = 1f32 };
+        let mut val = state.val; // [0,1]
+        if val < 0f32 { val = 0f32 };
+        if val > 1f32 { val = 1f32 };
+
+        // convert
+        let hue_hue: u32 = (hue * 65536f32 / 360f32) as u32;
+        let hue_sat: u32 = (sat * 254f32) as u32;
+        let hue_val: u32 = (val * 254f32) as u32;
+        let hue_on = state.on;
+
+        // TODO: Work with api reference instead of instantiating one ad-hoc.
+        // Created issues in muti-treading.
+        let api = HueHubApi::new(self.hub_id.clone(), self.hub_ip.clone());
+        api.set_light_color(&self.hue_id, hue_hue, hue_sat, hue_val, hue_on);
+    }
+}

--- a/src/adapters/philips_hue/api/structs.rs
+++ b/src/adapters/philips_hue/api/structs.rs
@@ -1,0 +1,110 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use adapters::philips_hue::api::serde_json;
+
+use std::collections::BTreeMap;
+use serde::de::Deserialize;
+use core::fmt::Debug;
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct HueHubSettings {
+    pub config: HueHubSettingsConfig,
+    pub scenes: BTreeMap<String, serde_json::Value>,
+    pub lights: BTreeMap<String, HueHubSettingsLightEntry>,
+    pub sensors: BTreeMap<String, serde_json::Value>,
+    pub rules: BTreeMap<String, serde_json::Value>,
+    pub schedules: BTreeMap<String, serde_json::Value>,
+    pub groups: BTreeMap<String, serde_json::Value>,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct HueHubSettingsConfig {
+    pub whitelist: BTreeMap<String, HueHubSettingsConfigWhitelistEntry>,
+    pub portalconnection: String,
+    pub modelid: String,
+    pub proxyport: u32,
+    pub linkbutton: bool,
+    pub dhcp: bool,
+    pub factorynew: bool,
+    pub zigbeechannel: u32,
+    pub swupdate: BTreeMap<String, serde_json::Value>,
+    pub mac: String,
+    pub bridgeid: String,
+    pub ipaddress: String,
+    pub swversion: String,
+    pub apiversion: String,
+    #[serde(rename="UTC")]
+    pub utc: String,
+    pub localtime: String,
+    pub portalstate: BTreeMap<String, serde_json::Value>,
+    pub portalservices: bool,
+    pub proxyaddress: String,
+    pub name: String,
+    pub replacesbridgeid: serde_json::Value,
+    pub timezone: String,
+    pub gateway: String,
+    pub netmask: String,
+    pub backup: BTreeMap<String, serde_json::Value>,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct HueHubSettingsConfigWhitelistEntry {
+    pub name: String,
+    #[serde(rename="create date")]
+    pub create_date: String,
+    #[serde(rename="last use date")]
+    pub last_use_date: String,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct HueHubSettingsLightEntry {
+    pub swversion: String,
+    pub modelid: String,
+    pub name: String,
+    pub uniqueid: String,
+    #[serde(rename="type")]
+    pub lighttype: String,
+    pub pointsymbol: BTreeMap<String, String>,
+    pub manufacturername: String,
+    pub state: HueHubSettingsLightState,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct HueHubSettingsLightState {
+    pub on: bool,
+    pub ct: u32,
+    pub reachable: bool,
+    pub effect: String,
+    pub sat: u32,
+    pub bri: u32,
+    pub colormode: String,
+    pub hue: u32,
+    pub xy: Vec<f32>,
+    pub alert: String,
+}
+
+impl HueHubSettings {
+    pub fn new(json: &String) -> Option<HueHubSettings> {
+        parse_json(json)
+    }
+}
+
+impl HueHubSettingsLightEntry {
+    pub fn new(json: &String) -> Option<Self> {
+        parse_json(json)
+    }
+}
+
+pub fn parse_json<T: Deserialize + Debug> (json: &String) -> Option<T> {
+    let parsed: Option<T> = match serde_json::from_str(&json) {
+        Ok(value) => Some(value),
+        Err(error) => {
+            error!("Unable to parse JSON {}. Error: {}", json, error.to_string());
+            None
+        }
+    };
+    debug!("Parsed JSON result: {:?}", parsed);
+    parsed
+}

--- a/src/adapters/philips_hue/http.rs
+++ b/src/adapters/philips_hue/http.rs
@@ -1,0 +1,46 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#![allow(dead_code)]
+
+extern crate hyper;
+
+use std::io::Read;
+use std::error::Error;
+
+pub fn get(url: String) -> Result<String, Box<Error>> {
+    // return Ok(.to_owned());
+    let client = hyper::Client::new();
+    let mut res = try!(
+        client.get(&url)
+            .header(hyper::header::Connection::close())
+            .send());
+    let mut content = String::new();
+    try!(res.read_to_string(&mut content));
+    Ok(content.to_owned())
+}
+
+pub fn post(url: String, data: String) -> Result<String, Box<Error>> {
+    let client = hyper::Client::new();
+    let mut res = try!(
+        client.post(&url)
+            .body(&data)
+            .header(hyper::header::Connection::close())
+            .send());
+    let mut content = String::new();
+    try!(res.read_to_string(&mut content));
+    Ok(content.to_owned())
+}
+
+pub fn put(url: String, data: String) -> Result<String, Box<Error>> {
+    let client = hyper::Client::new();
+    let mut res = try!(
+        client.put(&url)
+            .body(&data)
+            .header(hyper::header::Connection::close())
+            .send());
+    let mut content = String::new();
+    try!(res.read_to_string(&mut content));
+    Ok(content.to_owned())
+}

--- a/src/adapters/philips_hue/mod.rs
+++ b/src/adapters/philips_hue/mod.rs
@@ -1,0 +1,290 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+extern crate serde_json;
+
+mod http;
+mod nupnp;
+mod api;
+
+use adapters::philips_hue::api::structs::*;
+use adapters::philips_hue::api::HueLight;
+use controller::Controller;
+use events::*;
+use iron::{ Request, Response, IronResult };
+use iron::headers::{ ContentType, AccessControlAllowOrigin };
+use iron::status::Status;
+use iron::method::Method;
+use router::Router;
+use service::{ Service, ServiceAdapter, ServiceProperties };
+use std::time::Duration;
+use std::thread;
+use uuid::Uuid;
+use std::io::Read;
+
+
+pub struct PhilipsHueAdapter<T> {
+    name: String,
+    controller: T,
+}
+
+impl<T: Controller> PhilipsHueAdapter<T> {
+    pub fn new(controller: T) -> Self {
+        debug!("Creating Philips Hue adapter");
+        PhilipsHueAdapter { name: "PhilipsHueAdapter".to_owned(),
+                       controller: controller,
+                     }
+    }
+}
+
+impl<T: Controller> ServiceAdapter for PhilipsHueAdapter<T> {
+    fn get_name(&self) -> String {
+        self.name.clone()
+    }
+
+    fn start(&self) {
+        let mut id = 0;
+        let controller = self.controller.clone();
+
+        thread::spawn(move || {
+            controller.send_event(
+                EventData::AdapterStart {
+                    name: "Philips Hue Service Adapter".to_owned()
+                }).unwrap();
+
+            let nupnp_hubs = nupnp::query();
+            debug!("nUPnP reported Philips Hue bridges: {:?}", nupnp_hubs);
+
+            let available_hubs = nupnp_hubs
+                .iter()
+                .filter(|hub| hub.is_available())
+                .collect::<Vec<_>>();
+
+            let paired_hubs = available_hubs
+                .iter()
+                .filter(|hub| {
+                    info!("Philips Hue bridge {} at {}", hub.id, hub.ip);
+
+                    // Querying the settings fails when not paired with the bridge
+                    if hub.is_paired() {
+                        true
+                    } else {
+                        info!("Push pairing button on Philips Hue Bridge ID {}", hub.id);
+
+                        // Try pairing for 120 seconds.
+                        for _ in 0..120 {
+                            controller.send_event(
+                                EventData::AdapterNotification {
+                                    info: format!(
+                                        "{{\"adapter\": \"philips_hue\", \"message\": \"NeedsPairing\", \"hub\": \"{}\"}}",
+                                        hub.id)
+                                }).unwrap();
+                            if hub.try_pairing() {
+                                break;
+                            }
+                            thread::sleep(Duration::from_millis(1000));
+                        }
+
+                        if hub.is_paired() {
+                            info!("Paired with Philips Hue Bridge ID {}", hub.id);
+                            controller.send_event(
+                                EventData::AdapterNotification {
+                                    info: format!(
+                                         "{{\"adapter\": \"philips_hue\", \"message\": \"PairingSuccess\", \"hub\": \"{}\"}}",
+                                         hub.id)
+                                 }).unwrap();
+                            true
+                        } else {
+                            warn!("Pairing timeout with Philips Hue Bridge ID {}", hub.id);
+                            controller.send_event(
+                                EventData::AdapterNotification {
+                                    info: format!(
+                                         "{{\"adapter\": \"philips_hue\", \"message\": \"PairingTimeout\", \"hub\": \"{}\"}}",
+                                         hub.id)
+                                 }).unwrap();
+                            false
+                        }
+                    }
+                })
+                .collect::<Vec<_>>();
+
+            for hub in &paired_hubs {
+                hub.is_available();
+                // Extract and log some info
+                let setting = hub.get_settings();
+                let hs = HueHubSettings::new(&setting).unwrap(); // TODO: no unwrap
+                info!(
+                    "Connected to Philips Hue bridge model {}, ID {}, software version {}, IP address {}",
+                    hs.config.modelid, hs.config.bridgeid, hs.config.swversion,
+                    hs.config.ipaddress);
+
+                let lights = hub.get_lights();
+                for light in lights {
+                    debug!("Spawning service for {:?}", light);
+                    id += 1;
+                    let service = HueLightService::new(controller.clone(), id, light);
+                    let service_id = service.get_properties().id;
+                    service.start();
+                    controller.add_service(Box::new(service));
+                    controller.send_event(EventData::ServiceStart { id: service_id }).unwrap();
+                }
+            }
+        });
+    }
+
+    fn stop(&self) {
+        info!("Stopping Philips Hue adapter");
+    }
+
+}
+
+struct HueLightService<T> {
+    controller: T,
+    properties: ServiceProperties,
+    light: HueLight,
+}
+
+impl<T: Controller> HueLightService<T> {
+    fn new(controller: T, id: u32, light: HueLight) -> Self {
+        debug!("Creating HueLightService {} for HueLight {:?}", id, light);
+        let service_id = Uuid::new_v4().to_simple_string();
+        HueLightService {
+            controller: controller.clone(),
+            properties: ServiceProperties {
+                id: service_id.clone(),
+                name: "philips hue service".to_owned(),
+                description: "Service for Philips Hue Light".to_owned(),
+                http_url: controller.get_http_root_for_service(service_id.clone()),
+                ws_url: controller.get_ws_root_for_service(service_id)
+            },
+            light: light
+        }
+    }
+
+    fn handle_get_request(&self, cmd: &str) -> IronResult<Response> {
+        match cmd {
+            "state" => {
+                // TODO: Every light.get_*() call produces a
+                // get request to the API. Fix requires major
+                // internal design change.
+                let status = self.light.get_settings();
+                let light_state = self.light.get_state();
+                let json = format!(
+                    "{{\"type\": \"{}\", \"available\": {}, \"on\": {}, \"hue\": {}, \"sat\": {}, \"val\": {}}}",
+                    "device/light/colorlight",
+                    status.state.reachable, status.state.on,
+                    light_state.hue, light_state.sat, light_state.val);
+                let mut response = Response::with(json);
+                response.status = Some(Status::Ok);
+                response.headers.set(ContentType::json());
+                response.headers.set(AccessControlAllowOrigin::Any);
+                Ok(response)
+            },
+            _ => {
+                error_response()
+            }
+        }
+    }
+
+    fn handle_put_request(&self, cmd: &str, body: String) -> IronResult<Response> {
+        match cmd {
+            "state" => {
+                debug!("Request body for state command: {}", body);
+                let state_cmd: Option<StateCmd> = parse_json(&body);
+                debug!("Parsed state command: {:?}", state_cmd);
+                match state_cmd {
+                    Some(value) => {
+                        let mut light_state = self.light.get_state();
+                        if let Some(on) = value.on { light_state.on = on; }
+                        if let Some(hue) = value.hue { light_state.hue = hue; }
+                        if let Some(sat) = value.sat { light_state.sat = sat; }
+                        if let Some(val) = value.val { light_state.val = val; }
+                        self.light.set_state(light_state);
+                        success_response()
+                    },
+                    None => {
+                        warn!("Invalid parameters in state command: {}", cmd);
+                        error_response()
+                    }
+                }
+            },
+            _ => {
+                warn!("Invalid command to Hue Light service: {}", cmd);
+                error_response()
+            }
+        }
+    }
+}
+
+impl<T: Controller> Service for HueLightService<T> {
+    fn get_properties(&self) -> ServiceProperties {
+        self.properties.clone()
+    }
+
+    // Starts the service, it will just spawn a thread and send messages once
+    // in a while.
+    fn start(&self) {
+        let props = self.properties.clone();
+        let controller = self.controller.clone();
+        let light = self.light.clone();
+        thread::spawn(move || {
+            controller.send_event(
+                EventData::ServiceStart { id: props.id.to_string() }).unwrap();
+            info!("Service {} started for Philips Hue light \"{}\" on bridge {}",
+                props.id, light.hue_id, light.hub_id);
+            loop {
+                // TODO: Monitor and manage state changes.
+                thread::sleep(Duration::from_millis(60000));
+            }
+        });
+    }
+
+    fn stop(&self) {
+        debug!("Service {} stopped for Philips Hue light \"{}\" on bridge {}",
+            self.properties.id, self.light.hue_id, self.light.hub_id);
+    }
+
+    // Processes a http request.
+    fn process_request(&self, req: &mut Request) -> IronResult<Response> {
+        let cmd = req.extensions.get::<Router>().unwrap().find("command").unwrap_or("");
+        debug!("Got command {} via {:?}", cmd, req);
+        match req.method {
+            Method::Get => {
+                self.handle_get_request(cmd)
+            },
+            Method::Put => {
+                let mut body = String::new();
+                req.body.read_to_string(&mut body).unwrap();
+                self.handle_put_request(cmd, body)
+            },
+            _ => {
+                error_response()
+            }
+        }
+    }
+}
+
+fn success_response() -> IronResult<Response> {
+    let mut response = Response::with("{\"result\": \"success\"}".to_owned());
+    response.status = Some(Status::Ok);
+    response.headers.set(ContentType::json());
+    response.headers.set(AccessControlAllowOrigin::Any);
+    Ok(response)
+}
+
+fn error_response() ->  IronResult<Response> {
+    let mut response = Response::with("{\"result\": \"error\"}".to_owned());
+    response.status = Some(Status::MethodNotAllowed);
+    response.headers.set(ContentType::json());
+    response.headers.set(AccessControlAllowOrigin::Any);
+    Ok(response)
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+struct StateCmd {
+    on: Option<bool>,
+    hue: Option<f32>,
+    sat: Option<f32>,
+    val: Option<f32>,
+}

--- a/src/adapters/philips_hue/nupnp.rs
+++ b/src/adapters/philips_hue/nupnp.rs
@@ -1,0 +1,45 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+extern crate serde_json;
+
+use adapters::philips_hue::http;
+use adapters::philips_hue::api::HueHubApi;
+
+#[derive(Serialize, Deserialize, Debug)]
+struct HueNupnpEntry {
+    id: String,
+    internalipaddress: String
+}
+
+pub fn query() -> Vec<HueHubApi> {
+    // "[{\"id\":\"001788fffe243755\",\"internalipaddress\":\"192.168.5.129\"}]"
+    debug!("query meethue");
+    let empty = String::from("[]");
+    let url = "http://www.meethue.com/api/nupnp".to_owned();
+    let content = http::get(url)
+        .unwrap_or(empty);
+    debug!("content: {:?}", content);
+    let hub_list = parse_response(content);
+    debug!("parsed: {:?}", hub_list);
+    hub_list
+}
+
+fn parse_response(content: String) -> Vec<HueHubApi> {
+    let mut hub_list: Vec<HueHubApi> = Vec::new();
+    let hubs: Vec<HueNupnpEntry> = match serde_json::from_str(&content) {
+        Ok(value) => value,
+        Err(error) => {
+            warn!("Unable to parse NUPnP response: {}", error.to_string());
+            Vec::<HueNupnpEntry>::new()
+        }
+    };
+    for hub in hubs {
+        let id = hub.id;
+        let ip = hub.internalipaddress;
+        let new_hub = HueHubApi::new(id.to_owned(), ip.to_owned());
+        hub_list.push(new_hub);
+    }
+    hub_list
+}

--- a/src/events.rs
+++ b/src/events.rs
@@ -6,8 +6,10 @@ extern crate mio;
 
 use service::ServiceID;
 
+#[allow(dead_code)]
 pub enum EventData {
     AdapterStart { name: String },
+    AdapterNotification { info: String },
     ServiceStart { id: ServiceID },
     ServiceStop { id: ServiceID }
 }
@@ -16,6 +18,7 @@ impl EventData {
     pub fn description(&self) -> String {
         let description = match *self {
             EventData::AdapterStart { ref name } => name,
+            EventData::AdapterNotification { ref info } => info,
             EventData::ServiceStart { ref id }
             | EventData::ServiceStop { ref id } => id,
         };

--- a/src/main.rs
+++ b/src/main.rs
@@ -42,7 +42,7 @@ extern crate uuid;
 extern crate ws;
 
 mod controller;
-mod dummy_adapter;
+mod adapters;
 mod events;
 mod http_server;
 mod managed_process;

--- a/src/service.rs
+++ b/src/service.rs
@@ -22,7 +22,7 @@ pub trait Service : Send + Sync {
     fn get_properties(&self) -> ServiceProperties;
     fn start(&self);
     fn stop(&self);
-    fn process_request(&self, req: &Request) -> IronResult<Response>;
+    fn process_request(&self, req: &mut Request) -> IronResult<Response>;
 }
 
 impl Serialize for Service {

--- a/src/service_router.rs
+++ b/src/service_router.rs
@@ -25,11 +25,13 @@ pub fn create<T: Controller>(controller: T) -> Router {
     });
 
     let c2 = controller.clone();
-    router.get(":service/:command", move |req: &mut Request| -> IronResult<Response> {
+    router.any(":service/:command", move |req: &mut Request| -> IronResult<Response> {
         // Call a function on a service.
-        let id = req.extensions.get::<Router>().unwrap().find("service").unwrap_or("");
-        c2.dispatch_service_request(id.to_owned(), req)
+        let id = req.extensions.get::<Router>().unwrap()
+            .find("service").unwrap_or("").to_owned();
+        c2.dispatch_service_request(id, req)
     });
+
 
     router
 }

--- a/src/stubs/service.rs
+++ b/src/stubs/service.rs
@@ -20,7 +20,7 @@ impl Service for ServiceStub {
     }
     fn start(&self)  {}
     fn stop(&self) {}
-    fn process_request(&self, _: &Request) -> IronResult<Response> {
+    fn process_request(&self, _: &mut Request) -> IronResult<Response> {
         Ok(Response::with("request processed"))
     }
 }


### PR DESCRIPTION
Here's a prototype implementation of the Philips Hue adapter. See the included `huedemo.sh` script for a quick intro to the prototype API. Neither adapter nor API are "done" in any other way than that they cover our user stories. This PR is mainly for getting _some help with writing tests_.

**Before you pair with a Hue bridge using this adapter, be warned that the current code leaves your Hue bridge with a predictable, though non-trivial, API token which presents a considerable security risk.** If you know how to remove API tokens from the bridge, please tell me how.

Run with `RUST_LOG=info cargo run` or `RUST_LOG=debug cargo run` to see the adapter's console output. The Hue adapter will attempt to pair with all local Hue bridges announced via _nUPnP_ for 120 seconds each, then gives up. Pairing requests are published via _AdapterInfo_ events and are also announced on the console.
