### PR TITLE
Eliminating `println!`

### DIFF
--- a/src/controller.rs
+++ b/src/controller.rs
@@ -80,7 +80,7 @@ impl FoxBox {
 impl Controller for FoxBox {
 
     fn run(&mut self) {
-        println!("Starting controller");
+        debug!("Starting controller");
 
         let mut event_loop = mio::EventLoop::new().unwrap();
         self.event_sender = Some(event_loop.channel());
@@ -165,7 +165,7 @@ impl Controller for FoxBox {
         for socket in self.websockets.lock().unwrap().values() {
             match socket.send(data.to_owned()) {
                 Ok(_) => (),
-                Err(err) => println!("Error sending to socket: {}", err)
+                Err(err) => error!("Error sending to socket: {}", err)
             }
         }
     }
@@ -180,21 +180,21 @@ impl mio::Handler for FoxBoxEventLoop {
     type Message = EventData;
 
     fn notify(&mut self, _: &mut EventLoop<Self>, data: EventData) {
-        println!("Receiving a notification! {}", data.description());
+        info!("Receiving a notification! {}", data.description());
 
         self.controller.broadcast_to_websockets(data.description());
 
         match data {
             EventData::ServiceStart { id } => {
-                println!("Service started: {:?}",
+                debug!("Service started: {:?}",
                          self.controller.get_service_properties(id.to_owned()));
 
-                println!("ServiceStart {} We now have {} services.",
+                info!("ServiceStart {} We now have {} services.",
                          id, self.controller.services_count());
             }
             EventData::ServiceStop { id } => {
                 self.controller.remove_service(id.clone());
-                println!("ServiceStop {} We now have {} services.",
+                info!("ServiceStop {} We now have {} services.",
                          id, self.controller.services_count());
             }
             _ => { }

--- a/src/ws_server.rs
+++ b/src/ws_server.rs
@@ -31,28 +31,28 @@ impl WsServer {
 impl<T: Controller> Handler for WsHandler<T> {
 
     fn on_open(&mut self, _: Handshake) -> Result<()> {
-        println!("Hello new ws connection");
+        info!("Hello new ws connection");
         self.controller.add_websocket(self.out.clone());
         Ok(())
     }
 
     fn on_message(&mut self, msg: Message) -> Result<()> {
-        println!("Message from websocket ({:?}): {}", self.out.token(), msg);
+        info!("Message from websocket ({:?}): {}", self.out.token(), msg);
 
         Ok(())
     }
 
     fn on_close(&mut self, code: CloseCode, reason: &str) {
         match code {
-            CloseCode::Normal => println!("The ws client is done with the connection."),
-            CloseCode::Away => println!("The ws client is leaving the site."),
-            _ => println!("The ws client encountered an error: {}.", reason),
+            CloseCode::Normal => info!("The ws client is done with the connection."),
+            CloseCode::Away => info!("The ws client is leaving the site."),
+            _ => error!("The ws client encountered an error: {}.", reason),
         }
 
         self.controller.remove_websocket(self.out.clone());
     }
 
     fn on_error(&mut self, err: Error) {
-        println!("The ws server encountered an error: {:?}", err);
+        error!("The ws server encountered an error: {:?}", err);
     }
 }


### PR DESCRIPTION
This should get rid of the remaining _println!_ calls. Where unsure I defaulted non-error output to _info!_ because we're still prototyping.
