### PR TITLE
Switching service error response to JSON

### DIFF
--- a/src/controller.rs
+++ b/src/controller.rs
@@ -97,10 +97,10 @@ impl Controller for FoxBox {
         let services = self.services.lock().unwrap();
         match services.get(&id) {
             None => {
-                let mut response = Response::with(format!("No Such Service: {}", id));
+                let mut response = Response::with(json!({ error: "NoSuchService", id: id }));
                 response.status = Some(Status::BadRequest);
                 response.headers.set(AccessControlAllowOrigin::Any);
-                response.headers.set(ContentType::plaintext());
+                response.headers.set(ContentType::json());
                 Ok(response)
             }
             Some(service) => {

--- a/src/service_router.rs
+++ b/src/service_router.rs
@@ -216,7 +216,7 @@ describe! service_router {
                             &mount).unwrap();
 
             let result = response::extract_body_to_string(response);
-            assert_eq!(result, "No Such Service: unknown-id");
+            assert_eq!(result, r#"{"error":"NoSuchService","id":"unknown-id"}"#);
         }
     }
 


### PR DESCRIPTION
Seems wrong to deliver plaintext errors there.
