### PR TITLE
registration: Split test into many small ones

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16,6 +16,7 @@ dependencies = [
  "mio 0.5.0 (git+https://github.com/carllerche/mio.git)",
  "mount 0.0.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "multicast_dns 0.1.0 (git+https://github.com/fxbox/multicast-dns.git?rev=a6e4bcc)",
+ "regex 0.1.54 (registry+https://github.com/rust-lang/crates.io-index)",
  "router 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rust-crypto 0.2.34 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.18 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,3 +36,4 @@ ws = { git = "https://github.com/housleyjk/ws-rs.git", rev = "d154fc5" }
 [dev-dependencies]
 stainless = "0.1.4"
 iron-test = "0.2.0"
+regex = "0.1.54"

--- a/src/main.rs
+++ b/src/main.rs
@@ -47,6 +47,9 @@ extern crate uuid;
 extern crate ws;
 extern crate multicast_dns;
 
+#[cfg(test)]
+extern crate regex;
+
 // Need to be declared first so to let the macros be visible from other modules.
 #[macro_use]
 mod utils;


### PR DESCRIPTION
Not a lot of changes done, except the tests now use `stainless` and are broken down into 4. r? @hfiguiere 
