### PR TITLE
Bump rustc to 2016-03-01: Accomodate with https://github.com/rust-lang/rust/pull/31928

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 sudo: required
 language: rust
 rust:
-    - nightly-2016-02-22
+    - nightly-2016-03-01
 cache:
     directories:
         - $HOME/.cargo

--- a/src/managed_process.rs
+++ b/src/managed_process.rs
@@ -20,7 +20,7 @@ const RESTART_TIME_THRESHOLD: f64 = 5.0; // seconds
 
 fn seconds_since_epoch() -> f64 {
     let now = SystemTime::now();
-    now.duration_from_earlier(UNIX_EPOCH).unwrap().as_secs() as f64
+    now.duration_since(UNIX_EPOCH).unwrap().as_secs() as f64
 }
 
 pub struct ManagedProcess {


### PR DESCRIPTION
This PR fixes error below:
Compiling foxbox_users v0.1.0 (https://github.com/fxbox/users.git?rev=80bf99f#80bf99fb)
src/managed_process.rs:23:9: 23:30 error: use of unstable library feature 'time2_old': renamed to duration_since (see issue #29866)
src/managed_process.rs:23     now.duration_from_earlier(UNIX_EPOCH).unwrap().as_secs() as f64
