### PR TITLE
Moving Hue demo script

### DIFF
--- a/docs/scripts/huedemo.sh
+++ b/docs/scripts/huedemo.sh
@@ -1,8 +1,10 @@
 #!/bin/bash
 
+# You must disable authenticaion before using this script.
+# See https://github.com/fxbox/foxbox#disable-authentication
+
 HOST="localhost:3000"
 VAL=0.2
-
 
 huecmd() {
 	id=$1


### PR DESCRIPTION
The script was broken by the authentication requirement. Removing it until someone finds time to add authentication support.

**EDIT**

As per @ferjm's comment I'm just moving the script out of the way.
