### PR TITLE
Implementing config override, support for nUPnP server

### DIFF
--- a/src/adapters/philips_hue/mod.rs
+++ b/src/adapters/philips_hue/mod.rs
@@ -31,9 +31,10 @@ pub struct PhilipsHueAdapter<T> {
 impl<T: Controller> PhilipsHueAdapter<T> {
     pub fn new(controller: T) -> Self {
         debug!("Creating Philips Hue adapter");
-        PhilipsHueAdapter { name: "PhilipsHueAdapter".to_owned(),
-                       controller: controller,
-                     }
+        PhilipsHueAdapter {
+            name: "PhilipsHueAdapter".to_owned(),
+            controller: controller,
+        }
     }
 }
 
@@ -49,7 +50,9 @@ impl<T: Controller> ServiceAdapter for PhilipsHueAdapter<T> {
         thread::spawn(move || {
             controller.adapter_started("Philips Hue Service Adapter".to_owned());
 
-            let nupnp_hubs = nupnp::query("http://www.meethue.com/api/nupnp");
+            let nupnp_url = controller.get_config().get_or_set_default(
+                    "philips_hue", "nupnp_url", "http://www.meethue.com/api/nupnp");
+            let nupnp_hubs = nupnp::query(&nupnp_url);
             debug!("nUPnP reported Philips Hue bridges: {:?}", nupnp_hubs);
 
             for hub in nupnp_hubs {
@@ -68,7 +71,8 @@ impl<T: Controller> ServiceAdapter for PhilipsHueAdapter<T> {
                         // Try pairing for 120 seconds.
                         for _ in 0..120 {
                             controller.adapter_notification(
-                                json_value!({ adapter: "philips_hue", message: "NeedsPairing", hub: hub.id }));
+                                json_value!({ adapter: "philips_hue",
+                                    message: "NeedsPairing", hub: hub.id }));
                             if hub.try_pairing() {
                                 break;
                             }
@@ -115,7 +119,7 @@ impl<T: Controller> ServiceAdapter for PhilipsHueAdapter<T> {
     }
 
 }
- 
+
 #[allow(dead_code)]
 struct HueLightService<T> {
     controller: T,

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -57,6 +57,7 @@ pub trait Controller : Send + Sync + Clone + Reflect + 'static {
     fn remove_websocket(&mut self, socket: ws::Sender);
     fn broadcast_to_websockets(&self, data: serde_json::value::Value);
 
+    fn get_config(&self) -> &ConfigService;
     fn get_upnp_manager(&self) -> Arc<UpnpManager>;
 }
 
@@ -77,7 +78,7 @@ impl FoxBox {
             http_port: http_port,
             ws_port: ws_port,
             config: Arc::new(ConfigService::new("foxbox.conf")),
-            upnp: Arc::new(UpnpManager::new()),
+            upnp: Arc::new(UpnpManager::new())
         }
     }
 }
@@ -198,11 +199,16 @@ impl Controller for FoxBox {
         }
     }
 
+    fn get_config(&self) -> &ConfigService {
+        &self.config
+    }
+
     fn get_upnp_manager(&self) -> Arc<UpnpManager> {
         self.upnp.clone()
     }
 }
 
+#[allow(dead_code)]
 struct FoxBoxEventLoop<'a> {
     controller: FoxBox,
     shutdown_flag: &'a AtomicBool

--- a/src/main.rs
+++ b/src/main.rs
@@ -81,7 +81,7 @@ use std::mem;
 use std::sync::atomic::{ AtomicBool, Ordering, ATOMIC_BOOL_INIT };
 
 docopt!(Args derive Debug, "
-Usage: foxbox [-v] [-h] [-n <hostname>] [-p <port>] [-w <wsport>] [-r <url>] [-i <iface>] [-t <tunnel>]
+Usage: foxbox [-v] [-h] [-n <hostname>] [-p <port>] [-w <wsport>] [-r <url>] [-i <iface>] [-t <tunnel>] [-c <namespace;key;value>]...
 
 Options:
     -v, --verbose            Toggle verbose output.
@@ -91,6 +91,7 @@ Options:
     -r, --register <url>     Change the url of the registration endpoint. [default: http://localhost:4242/register]
     -i, --iface <iface>      Specify the local IP interface.
     -t, --tunnel <tunnel>    Set the tunnel endpoint's hostname. If omitted, the tunnel is disabled.
+    -c, --config <namespace;key;value>  Set configuration override
     -h, --help               Print this help menu.
 ",
         flag_name: Option<String>,
@@ -98,7 +99,8 @@ Options:
         flag_wsport: u16,
         flag_register: String,
         flag_iface: Option<String>,
-        flag_tunnel: Option<String>);
+        flag_tunnel: Option<String>,
+        flag_config: Option<Vec<String>>);
 
 /// Updates local host name with the provided host name string. If requested host name
 /// is not available (used by anyone else on the same network) then collision
@@ -154,6 +156,24 @@ fn main() {
         args.flag_verbose, args.flag_name.map_or(None, update_hostname), args.flag_port,
         args.flag_wsport);
 
+    // Override config values
+    {
+        if let Some(flags) = args.flag_config {
+            for flag in flags {
+                let items: Vec<String> = utils::split_escaped(&flag, ';');
+                if items.len() >= 3 {
+                    let namespace = items[0].clone();
+                    let key = items[1].clone();
+                    let value = items[2..].join(";");
+                    warn!("Setting config override: {}::{}->{}", namespace, key, value);
+                    controller.config.set_override(&namespace, &key, &value);
+                } else {
+                    error!("Config override requires three fields: {}", flag)
+                }
+            }
+        }
+    }
+
     controller.run(&SHUTDOWN_FLAG);
 
     if let Some(mut tunnel) = tunnel {
@@ -176,6 +196,7 @@ describe! main {
             assert_eq!(args.flag_register, "http://localhost:4242/register");
             assert_eq!(args.flag_iface, None);
             assert_eq!(args.flag_tunnel, None);
+            assert_eq!(args.flag_config, None);
             assert_eq!(args.flag_help, false);
         }
 
@@ -187,7 +208,8 @@ describe! main {
                                "-w", "4567",
                                "-r", "http://foo.bar:6868/register",
                                "-i", "eth99",
-                               "-t", "tunnel.host"];
+                               "-t", "tunnel.host",
+                               "-c", "ns;key;value"];
 
            let args: super::super::Args = super::super::Args::docopt().argv(argv().into_iter())
                .decode().unwrap();
@@ -199,6 +221,7 @@ describe! main {
             assert_eq!(args.flag_register, "http://foo.bar:6868/register");
             assert_eq!(args.flag_iface.unwrap(), "eth99");
             assert_eq!(args.flag_tunnel.unwrap(), "tunnel.host");
+            assert_eq!(args.flag_config.unwrap(), vec!["ns;key;value"]);
         }
 
         it "should support long form" {
@@ -209,7 +232,8 @@ describe! main {
                                "--wsport", "4567",
                                "--register", "http://foo.bar:6868/register",
                                "--iface", "eth99",
-                               "--tunnel", "tunnel.host"];
+                               "--tunnel", "tunnel.host",
+                               "--config", "ns;key;value"];
 
             let args: super::super::Args = super::super::Args::docopt().argv(argv().into_iter())
                 .decode().unwrap();
@@ -221,6 +245,7 @@ describe! main {
             assert_eq!(args.flag_register, "http://foo.bar:6868/register");
             assert_eq!(args.flag_iface.unwrap(), "eth99");
             assert_eq!(args.flag_tunnel.unwrap(), "tunnel.host");
+            assert_eq!(args.flag_config.unwrap(), vec!["ns;key;value"]);
         }
     }
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -160,3 +160,68 @@ pub fn parse_simple_xml<R: Read>(data: R) -> Result<HashMap<String, String>, Str
     }
     Ok(values)
 }
+
+#[allow(dead_code)]
+pub fn escape(unescaped_string: &str, to_escape: Vec<char>) -> String {
+    let mut escaped_string = String::new();
+    for chr in unescaped_string.to_owned().chars() {
+        if chr == '\\' || to_escape.contains(&chr) {
+            escaped_string.push('\\');
+        }
+        escaped_string.push(chr);
+    }
+    escaped_string
+}
+
+#[allow(dead_code)]
+pub fn unescape(escaped_string: &str) -> String {
+    let mut unescaped_string = String::new();
+    let mut escape_flag = false;
+    for chr in escaped_string.to_owned().chars() {
+        if escape_flag {
+            escape_flag = false;
+            unescaped_string.push(chr);
+        } else if chr == '\\' {
+            escape_flag = true;
+        } else {
+            unescaped_string.push(chr);
+        }
+    }
+    unescaped_string
+}
+
+pub fn split_escaped(string: &str, separator: char) -> Vec<String> {
+    let mut split = Vec::new();
+    let mut section = String::new();
+    let mut escape_flag = false;
+    for chr in string.to_owned().chars() {
+        if escape_flag {
+            escape_flag = false;
+            section.push(chr);
+        } else if chr == '\\' {
+            escape_flag = true;
+        } else if chr == separator {
+            split.push(section);
+            section = String::new();
+        } else {
+            section.push(chr);
+        }
+    }
+    split.push(section);
+    split
+}
+
+#[cfg(test)]
+describe! string_escaping {
+    it "should escape strings" {
+        assert_eq!(escape(r#"foo;bar\baz"#, vec![';']), r#"foo\;bar\\baz"#.to_owned())
+    }
+
+    it "should unescape strings" {
+        assert_eq!(unescape(r#"foo\;bar\\b\az"#), r#"foo;bar\baz"#.to_owned())
+    }
+
+    it "should split escaped strings" {
+        assert_eq!(split_escaped(r#"foo\;foo;bar;"#, ';'), vec!["foo;foo", "bar", ""]);
+    }
+}


### PR DESCRIPTION
The nUPnp server for Philips Hue can be overridden by running:

$ cargo run -- -c "philips_hue;nupnp_url;http://localhost:2342/"

You can specify multiple configuration overrides on the command line.
