### PR TITLE
authorizing websocket connections

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8,7 +8,7 @@ dependencies = [
  "docopt_macros 0.6.81 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "foxbox_taxonomy 0.1.2 (git+https://github.com/fxbox/taxonomy.git?rev=2dcf729)",
- "foxbox_users 0.1.0 (git+https://github.com/fxbox/users.git?rev=80bf99f)",
+ "foxbox_users 0.1.0 (git+https://github.com/fxbox/users.git?rev=a9b86cd)",
  "get_if_addrs 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "iron 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -183,11 +183,11 @@ dependencies = [
 [[package]]
 name = "foxbox_users"
 version = "0.1.0"
-source = "git+https://github.com/fxbox/users.git?rev=80bf99f#80bf99fbf9e7a4b0647608a8164ec6a73b9a6bc0"
+source = "git+https://github.com/fxbox/users.git?rev=a9b86cd#a9b86cd75b2b7f83dc59a055b7e7919c94b8f001"
 dependencies = [
  "iron 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "jwt 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "router 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rusqlite 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ clippy = "0.0.48"
 docopt = "0.6.78"
 docopt_macros = "0.6.80"
 env_logger = "0.3.2"
-foxbox_users = { git = "https://github.com/fxbox/users.git", rev = "80bf99f" }
+foxbox_users = { git = "https://github.com/fxbox/users.git", rev = "a9b86cd" }
 foxbox_taxonomy = { git = "https://github.com/fxbox/taxonomy.git", rev = "2dcf729" }
 get_if_addrs = "0.3.1"
 hyper = "0.7.2"

--- a/src/ws_server.rs
+++ b/src/ws_server.rs
@@ -1,11 +1,15 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+extern crate url;
 
+use controller::Controller;
+use foxbox_users::auth_middleware::AuthMiddleware;
+use self::url::Url;
 use std::thread;
+use ws;
 use ws::{ Handler, Sender, Result, Message, Handshake, CloseCode, Error };
 use ws::listen;
-use controller::Controller;
 
 pub struct WsServer;
 
@@ -28,11 +32,47 @@ impl WsServer {
     }
 }
 
+impl<T: Controller> WsHandler<T> {
+
+    fn close_with_error(&mut self, reason: &'static str) -> Result<()> {
+        self.out.close_with_reason(ws::CloseCode::Error, reason);
+        Ok(())
+    }
+}
+
 impl<T: Controller> Handler for WsHandler<T> {
 
-    fn on_open(&mut self, _: Handshake) -> Result<()> {
+    fn on_open(&mut self, handshake: Handshake) -> Result<()> {
         info!("Hello new ws connection");
+
+        let resource = &handshake.request.resource()[..];
+
+        // creating a fake url to get the path and query parsed
+        let url = match Url::parse(&format!("http://box.fox{}", resource)) {
+            Ok(val) => val,
+            _ => return self.close_with_error("Invalid path"),
+        };
+
+        let auth = match url.query_pairs() {
+            Some(pairs) => {
+                pairs.iter()
+                    .find(|ref set| set.0.to_lowercase() == "auth")
+                    .map(|ref set| set.1.clone())
+            },
+            _ => return self.close_with_error("Missing authorization"),
+        };
+
+        let token = match auth {
+            Some(val) => val,
+            _ => return self.close_with_error("Missing authorization"),
+        };
+
+        if let Err(_) = AuthMiddleware::verify(&token) {
+            return self.close_with_error("Authorization failed");
+        }
+
         self.controller.add_websocket(self.out.clone());
+
         Ok(())
     }
 


### PR DESCRIPTION
~~Depends on https://github.com/fxbox/users/pull/60~~

~~The `Cargo.*` file changes can be ignored. They are are artifacts of working with a local copy of https://github.com/fxbox/users/pull/60 checked out.~~

Accessing the headers of the `ws-rs` request wasn't great. We may want to move over to `rust-websocket`, which IIRC, uses the same `hyper::header` module that Iron does. That would reduce all the header shenanigans in this PR and be more elegant like what we see in the `fxbox/users` Iron middleware.

To test this you just add `?auth=<jwt>` to the websocket url.
