### PR TITLE
Fix #169 - Error: unknown field "resourcelinks"

### DIFF
--- a/src/adapters/philips_hue/hub_api/structs.rs
+++ b/src/adapters/philips_hue/hub_api/structs.rs
@@ -17,6 +17,7 @@ pub struct Settings {
     pub rules: BTreeMap<String, serde_json::Value>,
     pub schedules: BTreeMap<String, serde_json::Value>,
     pub groups: BTreeMap<String, serde_json::Value>,
+    pub resourcelinks: Option<BTreeMap<String, serde_json::Value>>,
 }
 
 #[derive(Serialize, Deserialize, Debug)]


### PR DESCRIPTION
This one line change enables the Philips Hue in the Paris office.

I wish I could add unit tests to the patch but I didn't manage to pass a correct JSON to `parse_json`. If I remember correctly, this part is not stable yet, so I could wait a bit more before investigating further. What do you think @cr ?

r? @cr 
