### PR TITLE
Fix warning calling close_with_reason

### DIFF
--- a/src/ws_server.rs
+++ b/src/ws_server.rs
@@ -35,8 +35,7 @@ impl WsServer {
 impl<T: Controller> WsHandler<T> {
 
     fn close_with_error(&mut self, reason: &'static str) -> Result<()> {
-        self.out.close_with_reason(ws::CloseCode::Error, reason);
-        Ok(())
+        self.out.close_with_reason(ws::CloseCode::Error, reason)
     }
 }
 


### PR DESCRIPTION
@jedireza f? No sure why you ignored the result and returned Ok(). But this cause a warning.
