### PR TITLE
Adapter API now uses transformable_channels instead of raw callbacks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7,8 +7,8 @@ dependencies = [
  "docopt 0.6.78 (registry+https://github.com/rust-lang/crates.io-index)",
  "docopt_macros 0.6.81 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "foxbox_adapters 0.1.0 (git+https://github.com/fxbox/adapters.git?rev=7a3f2de)",
- "foxbox_taxonomy 0.1.2 (git+https://github.com/fxbox/taxonomy.git?rev=16e7f37)",
+ "foxbox_adapters 0.1.0 (git+https://github.com/fxbox/adapters.git?rev=ba54c80)",
+ "foxbox_taxonomy 0.1.2 (git+https://github.com/fxbox/taxonomy.git?rev=4ff36cd)",
  "foxbox_users 0.1.0 (git+https://github.com/fxbox/users.git?rev=5b5beaa)",
  "get_if_addrs 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -31,6 +31,7 @@ dependencies = [
  "staticfile 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.34 (registry+https://github.com/rust-lang/crates.io-index)",
  "timer 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "transformable_channels 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicase 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 0.5.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -68,7 +69,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "byteorder"
-version = "0.4.2"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -171,19 +172,20 @@ dependencies = [
 [[package]]
 name = "foxbox_adapters"
 version = "0.1.0"
-source = "git+https://github.com/fxbox/adapters.git?rev=7a3f2de#7a3f2de22107783a7c93ec9637bb81c575873a05"
+source = "git+https://github.com/fxbox/adapters.git?rev=ba54c80#ba54c80d2db63b2de77601d7acd664d0520f11ed"
 dependencies = [
  "clippy 0.0.48 (registry+https://github.com/rust-lang/crates.io-index)",
- "foxbox_taxonomy 0.1.2 (git+https://github.com/fxbox/taxonomy.git?rev=16e7f37)",
+ "foxbox_taxonomy 0.1.2 (git+https://github.com/fxbox/taxonomy.git?rev=4ff36cd)",
  "serde 0.6.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_macros 0.6.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "transformable_channels 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "foxbox_taxonomy"
 version = "0.1.2"
-source = "git+https://github.com/fxbox/taxonomy.git?rev=16e7f37#16e7f37e3aeb9e69e70ef0cbd1f47c2456f5aacd"
+source = "git+https://github.com/fxbox/taxonomy.git?rev=4ff36cd#4ff36cd85a259d51ea8b67b35d9ece339de012b9"
 dependencies = [
  "chrono 0.2.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "clippy 0.0.48 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -191,6 +193,7 @@ dependencies = [
  "serde_json 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_macros 0.6.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "string_cache 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "transformable_channels 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -200,7 +203,7 @@ source = "git+https://github.com/fxbox/users.git?rev=5b5beaa#5b5beaa1260cf07aab3
 dependencies = [
  "iron 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "jwt 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "router 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rusqlite 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -716,7 +719,7 @@ name = "sha1"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "byteorder 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byteorder 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -801,6 +804,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "traitobject"
 version = "0.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "transformable_channels"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,8 +14,8 @@ clippy = "0.0.48"
 docopt = "0.6.78"
 docopt_macros = "0.6.80"
 env_logger = "0.3.2"
-foxbox_adapters = { git = "https://github.com/fxbox/adapters.git", rev = "7a3f2de" }
-foxbox_taxonomy = { git = "https://github.com/fxbox/taxonomy.git", rev = "16e7f37" }
+foxbox_adapters = { git = "https://github.com/fxbox/adapters.git", rev = "ba54c80" }
+foxbox_taxonomy = { git = "https://github.com/fxbox/taxonomy.git", rev = "4ff36cd" }
 foxbox_users = { git = "https://github.com/fxbox/users.git", rev = "5b5beaa" }
 get_if_addrs = "0.3.1"
 hyper = "0.7.2"
@@ -33,6 +33,7 @@ serde = "0.6.13"
 serde_json = "0.6.0"
 serde_macros = "0.6.14"
 staticfile = "0.1.0"
+transformable_channels = "^0.1"
 unicase = "1.3.0"
 time = "0.1"
 timer = "0.1.6"

--- a/src/adapters/clock/mod.rs
+++ b/src/adapters/clock/mod.rs
@@ -2,15 +2,15 @@
 //! timestamp or the current time of day.
 
 use foxbox_adapters::adapter::*;
-use foxbox_taxonomy::api::{ AdapterError, ResultMap };
+use foxbox_taxonomy::api::{ Error, InternalError, ResultMap };
 use foxbox_taxonomy::values::{ Range, TimeStamp, Type, ValDuration, Value };
 use foxbox_taxonomy::services::*;
 use foxbox_taxonomy::util::Id;
 
-use std::collections::{ HashMap, HashSet };
+use transformable_channels::mpsc::*;
+
+use std::collections::{ HashSet };
 use std::sync::Arc;
-use std::thread;
-use std::sync::mpsc:: { channel, Sender };
 
 use chrono;
 use chrono::*;
@@ -33,8 +33,6 @@ pub struct Clock {
     timer: timer::Timer,
     getter_timestamp_id: Id<Getter>,
     getter_time_of_day_id: Id<Getter>,
-
-    service_clock_id: Id<ServiceId>,
 }
 
 /// A guard used to cancel watching for values.
@@ -73,7 +71,7 @@ impl Adapter for Clock {
         &ADAPTER_VERSION
     }
 
-    fn fetch_values(&self, set: Vec<Id<Getter>>) -> ResultMap<Id<Getter>, Option<Value>, AdapterError> {
+    fn fetch_values(&self, set: Vec<Id<Getter>>) -> ResultMap<Id<Getter>, Option<Value>, Error> {
         set.iter().map(|id| {
             if *id == self.getter_timestamp_id {
                 let date = TimeStamp::from_datetime(chrono::UTC::now());
@@ -84,103 +82,99 @@ impl Adapter for Clock {
                 let duration = chrono::Duration::seconds(date.num_seconds_from_midnight() as i64);
                 (id.clone(), Ok(Some(Value::Duration(ValDuration::new(duration)))))
             } else {
-                (id.clone(), Err(AdapterError::NoSuchGetter(id.clone())))
+                (id.clone(), Err(Error::InternalError(InternalError::NoSuchGetter(id.clone()))))
             }
         }).collect()
     }
 
-    fn send_values(&self, values: Vec<(Id<Setter>, Value)>) -> ResultMap<Id<Setter>, (), AdapterError> {
+    fn send_values(&self, values: Vec<(Id<Setter>, Value)>) -> ResultMap<Id<Setter>, (), Error> {
         values.iter()
             .map(|&(ref id, _)| {
-                (id.clone(), Err(AdapterError::NoSuchSetter(id.clone())))
+                (id.clone(), Err(Error::InternalError(InternalError::NoSuchSetter(id.clone()))))
             })
             .collect()
     }
 
     fn register_watch(&self, mut watch: Vec<(Id<Getter>, Option<Range>)>,
-        cb: Box<Fn(WatchEvent) + Send>) ->
-            ResultMap<Id<Getter>, Box<AdapterWatchGuard>, AdapterError>
+        tx: Box<ExtSender<WatchEvent>>) ->
+            ResultMap<Id<Getter>, Box<AdapterWatchGuard>, Error>
     {
-        let (tx, rx) = channel();
-        thread::spawn(move || {
-            let cb = cb;
-            for msg in rx {
-                match msg {
-                    Op::Enter(id, value) => {
-                        cb(WatchEvent::Enter {
-                            id: id,
-                            value: value
-                        })
-                    },
-                    Op::Exit(id, value) => {
-                        cb(WatchEvent::Exit {
-                            id: id,
-                            value: value
-                        })
-                    },
-                }
+        let tx = tx.map(|msg| {
+            match msg {
+                Op::Enter(id, value) => {
+                    WatchEvent::Enter {
+                        id: id,
+                        value: value
+                    }
+                },
+                Op::Exit(id, value) => {
+                    WatchEvent::Exit {
+                        id: id,
+                        value: value
+                    }
+                },
             }
         });
         watch.drain(..).map(|(id, filter)| {
             (id.clone(), match filter {
-                None => Err(AdapterError::GetterRequiresThresholdForWatching(id)),
-                Some(range) => self.aux_register_watch(&id, range, tx.clone())
+                None => Err(Error::GetterRequiresThresholdForWatching(id)),
+                Some(range) => self.aux_register_watch(&id, range, Box::new(tx.clone()))
             })
         }).collect()
     }
 }
 
 impl Clock {
-    fn aux_register_watch(&self, id: &Id<Getter>, range: Range, tx: Sender<Op>)
-        -> Result<Box<AdapterWatchGuard>, AdapterError>
+    fn aux_register_watch(&self, id: &Id<Getter>, range: Range, tx: Box<ExtSender<Op>>)
+        -> Result<Box<AdapterWatchGuard>, Error>
     {
         match () {
             _ if *id == self.getter_time_of_day_id => self.aux_register_watch_timeofday(id, range, tx),
             _ if *id == self.getter_timestamp_id => self.aux_register_watch_timestamp(id, range, tx),
-            _ => Err(AdapterError::GetterDoesNotSupportWatching(id.clone()))
+            _ => Err(Error::GetterDoesNotSupportWatching(id.clone()))
         }
     }
 
-    fn aux_register_watch_timeofday(&self, id: &Id<Getter>, range: Range, tx: Sender<Op>)
-        -> Result<Box<AdapterWatchGuard>, AdapterError>
+    fn aux_register_watch_timeofday(&self, id: &Id<Getter>, range: Range, tx: Box<ExtSender<Op>>)
+        -> Result<Box<AdapterWatchGuard>, Error>
     {
         use foxbox_taxonomy::values::Range::*;
 
         // Sanity checks
-        let typ = try!(range.get_type().map_err(AdapterError::TypeError));
-        try!(Type::Duration.ensure_eq(&typ).map_err(AdapterError::TypeError));
+        let typ = try!(range.get_type().map_err(Error::TypeError));
+        try!(Type::Duration.ensure_eq(&typ).map_err(Error::TypeError));
 
         // Now determine when to call the trigger. Repeat duration is always one day.
         let mut thresholds = match range {
             Leq (ref val) => {
                 // Equivalent to BetweenEq { min: 0am, max: val }
-                let ts = *try!(val.as_duration().map_err(AdapterError::TypeError))
+                let ts = *try!(val.as_duration().map_err(Error::TypeError))
                     .as_duration();
                 vec![(Movement::Enter, Duration::seconds(0)), (Movement::Exit, ts)]
             }
             Geq (ref val) => {
                 // Equivalent to BetweenEq { min: val, max: 0am }
-                let ts = *try!(val.as_duration().map_err(AdapterError::TypeError))
+                let ts = *try!(val.as_duration().map_err(Error::TypeError))
                     .as_duration();
                 vec![(Movement::Enter, ts), (Movement::Exit, Duration::days(1))]
             }
             BetweenEq { ref min, ref max } => {
-                let ts_min = *try!(min.as_duration().map_err(AdapterError::TypeError))
+                let ts_min = *try!(min.as_duration().map_err(Error::TypeError))
                     .as_duration();
-                let ts_max = *try!(max.as_duration().map_err(AdapterError::TypeError))
+                let ts_max = *try!(max.as_duration().map_err(Error::TypeError))
                     .as_duration();
                 vec![(Movement::Enter, ts_min), (Movement::Exit, ts_max)]
             }
             OutOfStrict { ref min, ref max } => {
                 // Equivalent to BetweenEq {min: 0am, max: min} and BetweenEq {min: max, max: 0am}
-                let ts_min = *try!(min.as_duration().map_err(AdapterError::TypeError))
+                let ts_min = *try!(min.as_duration().map_err(Error::TypeError))
                     .as_duration();
-                let ts_max = *try!(max.as_duration().map_err(AdapterError::TypeError))
+                let ts_max = *try!(max.as_duration().map_err(Error::TypeError))
                     .as_duration();
                 vec![(Movement::Exit, ts_min), (Movement::Enter, ts_max)]
             }
             Eq (ref val) => {
-                let ts = *try!(val.as_duration().map_err(AdapterError::TypeError))
+                let ts = *try!(val.as_duration().map_err(Error::TypeError))
                     .as_duration();
                 vec![(Movement::Enter, ts.clone()), (Movement::Exit, ts)]
             }
@@ -215,17 +209,17 @@ impl Clock {
     }
 
     fn get_next_date(now: &DateTime<Local>, time_of_day: Duration)
-        -> Result<DateTime<Local>, AdapterError>
+        -> Result<DateTime<Local>, Error>
     {
         match chrono::Local::today().and_time(NaiveTime::from_hms(0, 0, 0) + time_of_day) {
-            None => Err(AdapterError::InvalidValue),
+            None => Err(Error::InvalidValue(Value::Duration(ValDuration::new(time_of_day)))),
             Some(date) => {
                 if date >= *now  {
                     Ok(date)
                 } else {
                     // Otherwise, shift to tomorrow.
                     match date.checked_add(Duration::days(1)) {
-                        None => Err(AdapterError::InvalidValue),
+                        None => Err(Error::InvalidValue(Value::Duration(ValDuration::new(time_of_day)))),
                         Some(date) => Ok(date)
                     }
                 }
@@ -233,14 +227,14 @@ impl Clock {
         }
     }
 
-    fn aux_register_watch_timestamp(&self, id: &Id<Getter>, range: Range, tx: Sender<Op>)
-        -> Result<Box<AdapterWatchGuard>, AdapterError>
+    fn aux_register_watch_timestamp(&self, id: &Id<Getter>, range: Range, tx: Box<ExtSender<Op>>)
+        -> Result<Box<AdapterWatchGuard>, Error>
     {
         use foxbox_taxonomy::values::Range::*;
 
         // Sanity checks
-        let typ = try!(range.get_type().map_err(AdapterError::TypeError));
-        try!(Type::TimeStamp.ensure_eq(&typ).map_err(AdapterError::TypeError));
+        let typ = try!(range.get_type().map_err(Error::TypeError));
+        try!(Type::TimeStamp.ensure_eq(&typ).map_err(Error::TypeError));
 
         // Now determine when/if to call the trigger.
         let mut thresholds = match range {
@@ -249,21 +243,21 @@ impl Clock {
                 return Ok(Box::new(Guard(vec![])))
             }
             Geq (ref val) | Eq (ref val) => {
-                let ts = *try!(val.as_timestamp().map_err(AdapterError::TypeError))
+                let ts = *try!(val.as_timestamp().map_err(Error::TypeError))
                     .as_datetime();
                 vec![(Movement::Enter, ts)]
             }
             OutOfStrict { ref min, ref max } => {
-                let ts_min = *try!(min.as_timestamp().map_err(AdapterError::TypeError))
+                let ts_min = *try!(min.as_timestamp().map_err(Error::TypeError))
                     .as_datetime();
-                let ts_max = *try!(max.as_timestamp().map_err(AdapterError::TypeError))
+                let ts_max = *try!(max.as_timestamp().map_err(Error::TypeError))
                     .as_datetime();
                 vec![(Movement::Exit, ts_min), (Movement::Enter, ts_max)]
             }
             BetweenEq { ref min, ref max } => {
-                let ts_min = *try!(min.as_timestamp().map_err(AdapterError::TypeError))
+                let ts_min = *try!(min.as_timestamp().map_err(Error::TypeError))
                     .as_datetime();
-                let ts_max = *try!(max.as_timestamp().map_err(AdapterError::TypeError))
+                let ts_max = *try!(max.as_timestamp().map_err(Error::TypeError))
                     .as_datetime();
                 vec![(Movement::Enter, ts_min), (Movement::Exit, ts_max)]
             }
@@ -298,7 +292,7 @@ impl Clock {
 }
 
 impl Clock {
-    pub fn init<T>(adapt: &Arc<T>) -> Result<(), AdapterError>
+    pub fn init<T>(adapt: &Arc<T>) -> Result<(), Error>
         where T: AdapterManagerHandle
     {
         let getter_timestamp_id = Clock::getter_timestamp_id();
@@ -308,45 +302,37 @@ impl Clock {
             timer: timer::Timer::new(),
             getter_timestamp_id: getter_timestamp_id.clone(),
             getter_time_of_day_id: getter_time_of_day_id.clone(),
-            service_clock_id: service_clock_id.clone(),
         });
-        adapt.add_adapter(clock, vec![Service {
-            adapter: Clock::id(),
-            tags: HashSet::new(),
-            id: service_clock_id.clone(),
-            setters: HashMap::new( /* No setters */ ),
-            getters: vec![
-                // Time of day
-                (getter_time_of_day_id.clone(), Channel {
-                    tags: HashSet::new(),
-                    adapter: Clock::id(),
-                    id: getter_time_of_day_id.clone(),
-                    last_seen: None,
-                    service: service_clock_id.clone(),
-                    mechanism: Getter {
-                        kind: ChannelKind::CurrentTimeOfDay,
-                        poll: Some(ValDuration::new(chrono::Duration::seconds(1))),
-                        trigger: None,
-                        watch: true,
-                        updated: None
-                    }
-                }),
-
-                // Current time
-                (getter_timestamp_id.clone(), Channel {
-                    tags: HashSet::new(),
-                    adapter: Clock::id(),
-                    id: getter_timestamp_id.clone(),
-                    last_seen: None,
-                    service: service_clock_id.clone(),
-                    mechanism: Getter {
-                        kind: ChannelKind::CurrentTime,
-                        poll: Some(ValDuration::new(chrono::Duration::seconds(1))),
-                        trigger: None,
-                        watch: true,
-                        updated: None
-                    }
-                })].iter().cloned().collect(),
-        }])
+        try!(adapt.add_adapter(clock));
+        try!(adapt.add_service(Service::empty(Clock::service_clock_id(), Clock::id())));
+        try!(adapt.add_getter(Channel {
+                tags: HashSet::new(),
+                adapter: Clock::id(),
+                id: getter_time_of_day_id.clone(),
+                last_seen: None,
+                service: service_clock_id.clone(),
+                mechanism: Getter {
+                    kind: ChannelKind::CurrentTimeOfDay,
+                    poll: Some(ValDuration::new(chrono::Duration::seconds(1))),
+                    trigger: None,
+                    watch: true,
+                    updated: None
+                }
+        }));
+        try!(adapt.add_getter(Channel {
+                tags: HashSet::new(),
+                adapter: Clock::id(),
+                id: getter_timestamp_id.clone(),
+                last_seen: None,
+                service: service_clock_id.clone(),
+                mechanism: Getter {
+                    kind: ChannelKind::CurrentTime,
+                    poll: Some(ValDuration::new(chrono::Duration::seconds(1))),
+                    trigger: None,
+                    watch: true,
+                    updated: None
+                }
+        }));
+        Ok(())
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -45,6 +45,7 @@ extern crate serde;
 extern crate staticfile;
 extern crate time;
 extern crate timer;
+extern crate transformable_channels;
 extern crate unicase;
 extern crate uuid;
 extern crate ws;


### PR DESCRIPTION
The use of raw callbacks caused us to fire two threads for watching the clock _per watch_ and it looked like other adapters, which need to deal with even more complex inputs, would be at least as bad. There was no way we could have sustained this number of threads in actual use. Using channels proved to have the exact same issue.

I have written a small crate transformable_channels that extends channels with `map`, `filter`, `filter_map`, which removes the need for all these phony threads. Crates foxbox_taxonomy and foxbox_adapters have been ported to use transformable_channels. This patch propagates the changes downstream.

By porting to transformable_channels, I have successfully removed the threads-per-watch. High-level client code is now once again in charge of deciding when and where to use threads.

For a complete discussion on raw callbacks vs. `Sender<>` vs. transformable_channels, and a Pre-RFC on transformable_channels, see https://internals.rust-lang.org/t/pre-rfc-transformations-on-channels/
