### PR TITLE
Don't fail to create profile directory when it already exists

### DIFF
--- a/src/profile_service.rs
+++ b/src/profile_service.rs
@@ -7,6 +7,7 @@
 
 use std::env;
 use std::fs;
+use std::io::ErrorKind;
 
 pub struct ProfileService {
     profile_dir: String
@@ -53,7 +54,9 @@ impl ProfileService {
             },
             Err(_) => {
                 fs::create_dir_all(dir.clone()).unwrap_or_else(|err| {
-                    panic!("Unable to create directory {} : {}", dir, err);
+                    if err.kind() != ErrorKind::AlreadyExists {
+                        panic!("Unable to create directory {} : {}", dir, err);
+                    }
                 });
             }
         }


### PR DESCRIPTION
I saw that failure in a PR test run:

---- controller::controller::add_service::should_create_http_root stdout ----

```
thread 'controller::controller::add_service::should_create_http_root' panicked at 'Unable to create directory /home/travis/.local/share/foxbox : File exists (os error 17)', src/profile_service.rs:56
```

note: Run with `RUST_BACKTRACE=1` for a backtrace.
