### PR TITLE
Fix the test hostname detection to not add .local. if it is localhost

### DIFF
--- a/test/selenium/sessions_ui_test.js
+++ b/test/selenium/sessions_ui_test.js
@@ -9,8 +9,8 @@ var webdriver = require('selenium-webdriver'),
 
 var HOST_URL = util.format(
     'http://%s:%s/',
-    process.env.BOX_LOCAL_NAME ?
-        (process.env.BOX_LOCAL_NAME + '.local') : 'localhost',
+    process.env.BOX_LOCAL_NAME && process.env.BOX_LOCAL_NAME != 'localhost' ?
+        (process.env.BOX_LOCAL_NAME + '.local.') : 'localhost',
     process.env.BOX_PORT || '3000'
 );
 


### PR DESCRIPTION
If you set BOX_LOCAL_NAME to localhost test won't work. This is was in the previous documentation.
Also add a final `.` to `.local.` because we don't want any domain name happened if there is a failure with the mDNS registration.
