### PR TITLE
Generate self-signed certificate, and post the domain with the fingerprint to the registration server.

### DIFF
--- a/src/stubs/controller.rs
+++ b/src/stubs/controller.rs
@@ -15,6 +15,7 @@ use service::{ Service, ServiceProperties };
 use std::io;
 use std::net::SocketAddr;
 use std::net::ToSocketAddrs;
+use std::path::PathBuf;
 use std::sync::Arc;
 use std::sync::atomic::AtomicBool;
 use tls::CertificateManager;
@@ -90,6 +91,6 @@ impl Controller for ControllerStub {
     }
 
     fn get_certificate_manager(&self) -> CertificateManager {
-       CertificateManager::new()
+       CertificateManager::new(PathBuf::from(current_dir!()))
     }
 }


### PR DESCRIPTION
This PR enables a few other things, would like to land this in stages.

This will generate a self-signed cert, even if we use --disable-tls, because we need to send a unique value (or certificate fingerprint) to the DNS API and the Registration server, and we can use the cert to authenticate the POSTs to these APIs.

This posts the 'domain' to the registration server, although it won't yet do anything with it until we land and deploy: https://github.com/fxbox/registration_server/pull/18 which requires a change in the app.
