### PR TITLE
Use ws_as_addrs to create the Websocket listener rather than passing in port and hostname.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7,7 +7,7 @@ dependencies = [
  "docopt 0.6.78 (registry+https://github.com/rust-lang/crates.io-index)",
  "docopt_macros 0.6.81 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "foxbox_taxonomy 0.1.2 (git+https://github.com/fxbox/taxonomy.git?rev=6840677)",
+ "foxbox_taxonomy 0.1.2 (git+https://github.com/fxbox/taxonomy.git?rev=d91bf85)",
  "foxbox_users 0.1.0 (git+https://github.com/fxbox/users.git?rev=73e8943)",
  "get_if_addrs 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -189,7 +189,7 @@ dependencies = [
 [[package]]
 name = "foxbox_taxonomy"
 version = "0.1.2"
-source = "git+https://github.com/fxbox/taxonomy.git?rev=6840677#684067789a20f915f45822dbb53a6fc08b32a26e"
+source = "git+https://github.com/fxbox/taxonomy.git?rev=d91bf85#d91bf8524309cdfe52a816b43ff97fb99600ee3d"
 dependencies = [
  "chrono 0.2.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "clippy 0.0.48 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -108,7 +108,7 @@ impl Controller for FoxBox {
         adapter_manager.start(&taxo_manager);
 
         HttpServer::new(self.clone()).start(taxo_manager);
-        WsServer::start(self.clone(), self.hostname.to_owned(), self.ws_port);
+        WsServer::start(self.clone());
 
         self.upnp.search(None).unwrap();
 
@@ -192,6 +192,10 @@ impl Controller for FoxBox {
 
     fn http_as_addrs(&self) -> Result<IntoIter<SocketAddr>, io::Error> {
         (self.hostname.as_str(), self.http_port).to_socket_addrs()
+    }
+
+    fn ws_as_addrs(&self) -> Result<IntoIter<SocketAddr>, io::Error> {
+        (self.hostname.as_str(), self.ws_port).to_socket_addrs()
     }
 
     fn add_websocket(&mut self, socket: ws::Sender) {

--- a/src/stubs/controller.rs
+++ b/src/stubs/controller.rs
@@ -70,6 +70,11 @@ impl Controller for ControllerStub {
     fn http_as_addrs(&self) -> Result<IntoIter<SocketAddr>, io::Error> {
         ("localhost", 3000).to_socket_addrs()
     }
+
+    fn ws_as_addrs(&self) -> Result<IntoIter<SocketAddr>, io::Error> {
+        ("localhost", 4000).to_socket_addrs()
+    }
+
     fn add_websocket(&mut self, socket: ws::Sender) {}
     fn remove_websocket(&mut self, socket: ws::Sender) {}
     fn broadcast_to_websockets(&self, data: serde_json::value::Value) {}

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -31,6 +31,7 @@ pub trait Controller : Send + Sync + Clone + Reflect + 'static {
     fn get_http_root_for_service(&self, service_id: String) -> String;
     fn get_ws_root_for_service(&self, service_id: String) -> String;
     fn http_as_addrs(&self) -> Result<IntoIter<SocketAddr>, io::Error>;
+    fn ws_as_addrs(&self) -> Result<IntoIter<SocketAddr>, io::Error>;
 
     fn get_tls_enabled(&self) -> bool;
     fn get_certificate_manager(&self) -> CertificateManager;

--- a/src/ws_server.rs
+++ b/src/ws_server.rs
@@ -19,9 +19,11 @@ pub struct WsHandler<T> {
 
 impl WsServer {
 
-    pub fn start<T: Controller>(controller: T, hostname: String, port: u16) {
+    pub fn start<T: Controller>(controller: T) {
+        let addrs: Vec<_> = controller.ws_as_addrs().unwrap().collect();
         thread::Builder::new().name("WsServer".to_owned()).spawn(move || {
-            listen((&hostname as &str, port), |out| {
+
+            listen(addrs[0], |out| {
                 WsHandler {
                     out: out,
                     controller: controller.clone(),


### PR DESCRIPTION
Trivial change to make the creation of the listener consistent with the HttpServer.

@mcav r?
