### PR TITLE
Include the scheme in the message posted to the registration server

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -282,7 +282,7 @@ fn main() {
     let registrar = registration::Registrar::new(controller.get_hostname());
     registrar.start(args.flag_register, args.flag_iface,
                     domain, &tunnel, args.flag_port,
-                    args.flag_dns_api, controller.get_certificate_manager());
+                    args.flag_dns_api, &controller);
 
     controller.run(&SHUTDOWN_FLAG);
 


### PR DESCRIPTION
Ideally the scheme needs to come from the controller, but I don't understand what is going on in the controller with `get_http_root_for_service` and the web socket equivalent as it is right now (the hostname is also potentially going to be wrong in there). The controller API needs reviewing before I make the right change as it's used in an adapter.  But for now: 

![The garbage will do](https://cloud.githubusercontent.com/assets/840334/14040495/0746c0de-f225-11e5-9438-c379a55720d8.gif)

@fabricedesre  r?
