### PR TITLE
Resolve #243 - Removing the big Mutex in taxonomy_router

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ before_script:
 
 script:
     - cargo build # Linter is also executed here
-    - cargo test
+    - RUST_BACKTRACE=1 cargo test
     - jshint static/main/js/*.js static/setup/js/*.js test/selenium/*.js test/integration/lib/*.js test/integration/test/*.js
     - npm run test-integration
     - npm run test-selenium

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2,13 +2,13 @@
 name = "foxbox"
 version = "0.1.0"
 dependencies = [
- "chrono 0.2.20 (registry+https://github.com/rust-lang/crates.io-index)",
+ "chrono 0.2.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "clippy 0.0.48 (registry+https://github.com/rust-lang/crates.io-index)",
  "docopt 0.6.78 (registry+https://github.com/rust-lang/crates.io-index)",
  "docopt_macros 0.6.81 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "foxbox_taxonomy 0.1.2 (git+https://github.com/fxbox/taxonomy.git?rev=32e99a1)",
- "foxbox_thinkerbell 0.1.2 (git+https://github.com/fxbox/thinkerbell.git)",
+ "foxbox_taxonomy 0.1.2 (git+https://github.com/fxbox/taxonomy.git?rev=ac8ee9f)",
+ "foxbox_thinkerbell 0.1.2 (git+https://github.com/fxbox/thinkerbell.git?rev=42e78df)",
  "foxbox_users 0.1.0 (git+https://github.com/fxbox/users.git?rev=73e8943)",
  "get_if_addrs 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -24,7 +24,7 @@ dependencies = [
  "openssl 0.7.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "openssl-sys 0.7.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex 0.1.58 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 0.1.60 (registry+https://github.com/rust-lang/crates.io-index)",
  "router 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rusqlite 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rust-crypto 0.2.34 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -75,11 +75,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "bodyparser"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "iron 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "persistent 0.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "iron 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "persistent 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "plugin 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -107,7 +107,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "chrono"
-version = "0.2.20"
+version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "num 0.1.31 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -156,7 +156,7 @@ name = "docopt"
 version = "0.6.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "regex 0.1.58 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 0.1.60 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "strsim 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -175,7 +175,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "log 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex 0.1.58 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 0.1.60 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -190,25 +190,26 @@ dependencies = [
 [[package]]
 name = "foxbox_taxonomy"
 version = "0.1.2"
-source = "git+https://github.com/fxbox/taxonomy.git?rev=32e99a1#32e99a14d553a216b5fe29726d213dd7eba9900f"
+source = "git+https://github.com/fxbox/taxonomy.git?rev=ac8ee9f#ac8ee9f222538f96ddfd428a09fd1bf5a8a5d6c0"
 dependencies = [
- "chrono 0.2.20 (registry+https://github.com/rust-lang/crates.io-index)",
+ "chrono 0.2.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "clippy 0.0.48 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 0.6.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_macros 0.6.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "string_cache 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sublock 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "transformable_channels 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "foxbox_thinkerbell"
 version = "0.1.2"
-source = "git+https://github.com/fxbox/thinkerbell.git#d88e270dd031454f689f11d2c2068507179f32fe"
+source = "git+https://github.com/fxbox/thinkerbell.git?rev=42e78df#42e78df6d5bede0e911faf7f367f9826e7692230"
 dependencies = [
- "chrono 0.2.20 (registry+https://github.com/rust-lang/crates.io-index)",
- "foxbox_taxonomy 0.1.2 (git+https://github.com/fxbox/taxonomy.git?rev=32e99a1)",
+ "chrono 0.2.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "foxbox_taxonomy 0.1.2 (git+https://github.com/fxbox/taxonomy.git?rev=ac8ee9f)",
  "rusqlite 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 0.6.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -448,6 +449,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "mempool"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "mime"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -502,6 +508,15 @@ version = "0.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "iron 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sequence_trie 0.0.13 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "mount"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "iron 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "sequence_trie 0.0.13 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -604,25 +619,25 @@ dependencies = [
 
 [[package]]
 name = "persistent"
-version = "0.0.9"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "iron 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "iron 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "plugin 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "phf_generator"
-version = "0.7.13"
+version = "0.7.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "phf_shared 0.7.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "phf_shared 0.7.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "phf_shared"
-version = "0.7.13"
+version = "0.7.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -686,12 +701,13 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "0.1.58"
+version = "0.1.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "aho-corasick 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "memchr 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex-syntax 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mempool 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex-syntax 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "utf8-ranges 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -702,7 +718,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "regex-syntax"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -856,7 +872,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "iron 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "mount 0.0.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mount 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.34 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 0.5.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -868,14 +884,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "debug_unreachable 0.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)",
- "phf_generator 0.7.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "phf_shared 0.7.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "phf_generator 0.7.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "phf_shared 0.7.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "strsim"
 version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "sublock"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -901,7 +922,7 @@ name = "timer"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "chrono 0.2.20 (registry+https://github.com/rust-lang/crates.io-index)",
+ "chrono 0.2.21 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -996,7 +1017,7 @@ name = "urlencoded"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "bodyparser 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bodyparser 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "iron 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "plugin 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 0.2.38 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,8 +14,8 @@ clippy = "0.0.48"
 docopt = "0.6.78"
 docopt_macros = "0.6.80"
 env_logger = "0.3.2"
-foxbox_taxonomy = { git = "https://github.com/fxbox/taxonomy.git", rev = "32e99a1" }
-foxbox_thinkerbell = { git = "https://github.com/fxbox/thinkerbell.git" }
+foxbox_taxonomy = { git = "https://github.com/fxbox/taxonomy.git", rev = "ac8ee9f" }
+foxbox_thinkerbell = { git = "https://github.com/fxbox/thinkerbell.git", rev = "42e78df" }
 foxbox_users = { git = "https://github.com/fxbox/users.git", rev = "73e8943" }
 get_if_addrs = "0.3.1"
 hyper = "0.7.2"

--- a/src/adapters/webpush/mod.rs
+++ b/src/adapters/webpush/mod.rs
@@ -16,10 +16,10 @@
 mod crypto;
 mod db;
 
-use foxbox_taxonomy::adapter::*;
 use foxbox_taxonomy::api::{ Error, InternalError };
-use foxbox_taxonomy::values::{ Range, Type, Value, Json };
+use foxbox_taxonomy::manager::*;
 use foxbox_taxonomy::services::*;
+use foxbox_taxonomy::values::{ Range, Type, Value, Json };
 
 #[cfg(not(target_os = "macos"))]
 use hyper::header::{ ContentEncoding, Encoding };
@@ -240,8 +240,8 @@ impl<C: Controller> Adapter for WebPush<C> {
 }
 
 impl<C: Controller> WebPush<C> {
-    pub fn init<A: AdapterManagerHandle>(controller: C, adapt: &A) -> Result<(), Error> {
-        let wp = Box::new(Self::new(controller));
+    pub fn init(controller: C, adapt: &Arc<AdapterManager>) -> Result<(), Error> {
+        let wp = Arc::new(Self::new(controller));
         let id = WebPush::<C>::id();
         let service_id = WebPush::<C>::service_webpush_id();
         let getter_resource_id = wp.getter_resource_id.clone();

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -7,7 +7,7 @@ extern crate mio;
 
 use adapters::AdapterManager;
 use config_store::ConfigService;
-use foxbox_taxonomy::manager::AdapterManager as AdapterManager2;
+use foxbox_taxonomy::manager::AdapterManager as TaxoManager;
 use foxbox_users::UsersManager;
 use http_server::HttpServer;
 use iron::{Request, Response, IronResult};
@@ -102,12 +102,12 @@ impl Controller for FoxBox {
         }
 
         // Create the taxonomy based AdapterManager
-        let taxo_manager = AdapterManager2::new();
+        let taxo_manager = Arc::new(TaxoManager::new());
 
         let mut adapter_manager = AdapterManager::new(self.clone());
-        adapter_manager.start(taxo_manager.clone());
+        adapter_manager.start(&taxo_manager);
 
-        HttpServer::new(self.clone()).start(taxo_manager);
+        HttpServer::new(self.clone()).start(&taxo_manager);
         WsServer::start(self.clone());
 
         self.upnp.search(None).unwrap();

--- a/src/http_server.rs
+++ b/src/http_server.rs
@@ -22,7 +22,7 @@ use taxonomy_router;
 use tls::SniServerFactory;
 use traits::Controller;
 
-const THREAD_COUNT: usize = 8;
+const THREAD_COUNT: usize = 64;
 
 struct Custom404;
 

--- a/tools/execute-selenium-tests
+++ b/tools/execute-selenium-tests
@@ -20,7 +20,7 @@ if [ "$(uname)" == "Darwin" ]; then
     # Do not use hostname flag on Mac since it is only implemented in Linux ATM.
     "$FOXBOX_BINARY" --port ${DEBUG_PORT} --disable-tls --profile "${DEBUG_PROFILE}" &
 else
-    "$FOXBOX_BINARY" --local-name ${DEBUG_HOST} --port ${DEBUG_PORT} --disable-tls --profile "${DEBUG_PROFILE}" &
+    strace "$FOXBOX_BINARY" --local-name ${DEBUG_HOST} --port ${DEBUG_PORT} --disable-tls --profile "${DEBUG_PROFILE}" &
 fi
 FOXBOX_PID=$!
 popd


### PR DESCRIPTION
To be compatible with Iron's thread pool, the taxonomy_router needs to
be Sync. This used to be implemented by putting everything in a big
Mutex.

Changes in Taxonomy have made the AdapterManager Sync and
thread-friendly. This patch propagates the changes to all Adapters
currently in FoxBox and to the taxonomy_router itself.
