### PR TITLE
[RFC] Resolves #37 Improve support for binary f?fabrice

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7,8 +7,8 @@ dependencies = [
  "docopt 0.6.78 (registry+https://github.com/rust-lang/crates.io-index)",
  "docopt_macros 0.6.81 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "foxbox_taxonomy 0.1.2 (git+https://github.com/fxbox/taxonomy.git?rev=8cad391)",
- "foxbox_thinkerbell 0.1.2 (git+https://github.com/fxbox/thinkerbell.git?rev=ec60634)",
+ "foxbox_taxonomy 0.1.2 (git+https://github.com/fxbox/taxonomy.git?rev=c8f05af)",
+ "foxbox_thinkerbell 0.1.2 (git+https://github.com/fxbox/thinkerbell.git?rev=84a0a30)",
  "foxbox_users 0.1.0 (git+https://github.com/fxbox/users.git?rev=73e8943)",
  "get_if_addrs 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -17,9 +17,11 @@ dependencies = [
  "iron-test 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mime 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "mio 0.5.0 (git+https://github.com/carllerche/mio.git)",
  "mount 0.0.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "multicast_dns 0.1.0 (git+https://github.com/fxbox/multicast-dns.git?rev=a6e4bcc)",
+ "multipart 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "nix 0.5.1-pre (git+https://github.com/nix-rust/nix.git?rev=138080)",
  "openssl 0.7.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "openssl-sys 0.7.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -190,7 +192,7 @@ dependencies = [
 [[package]]
 name = "foxbox_taxonomy"
 version = "0.1.2"
-source = "git+https://github.com/fxbox/taxonomy.git?rev=8cad391#8cad391d1276815430b799a4da3d3ccfc26343bc"
+source = "git+https://github.com/fxbox/taxonomy.git?rev=c8f05af#c8f05af71fa65e8876aa1f571e819a96b9e6769f"
 dependencies = [
  "chrono 0.2.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "clippy 0.0.48 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -206,10 +208,10 @@ dependencies = [
 [[package]]
 name = "foxbox_thinkerbell"
 version = "0.1.2"
-source = "git+https://github.com/fxbox/thinkerbell.git?rev=ec60634#ec606348c6ee05b32be0156de3a12a57def4d3e4"
+source = "git+https://github.com/fxbox/thinkerbell.git?rev=84a0a30#84a0a307248400b61607a3293f74f2e68b0d97d1"
 dependencies = [
  "chrono 0.2.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "foxbox_taxonomy 0.1.2 (git+https://github.com/fxbox/taxonomy.git?rev=8cad391)",
+ "foxbox_taxonomy 0.1.2 (git+https://github.com/fxbox/taxonomy.git?rev=c8f05af)",
  "rusqlite 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 0.6.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -471,6 +473,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "mime_guess"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "mime 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "phf 0.7.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "phf_codegen 0.7.14 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "mio"
 version = "0.5.0"
 source = "git+https://github.com/carllerche/mio.git#0a8089422d3bdf5ecb02593b4f68f25f8e985490"
@@ -527,6 +539,20 @@ source = "git+https://github.com/fxbox/multicast-dns.git?rev=a6e4bcc#a6e4bcc5ecb
 dependencies = [
  "libc 0.2.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "multipart"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "env_logger 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "iron 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mime 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mime_guess 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tempdir 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -624,6 +650,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "iron 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "plugin 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "phf"
+version = "0.7.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "phf_shared 0.7.14 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "phf_codegen"
+version = "0.7.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "phf_generator 0.7.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "phf_shared 0.7.14 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,8 +14,10 @@ clippy = "0.0.48"
 docopt = "0.6.78"
 docopt_macros = "0.6.80"
 env_logger = "0.3.2"
-foxbox_taxonomy = { git = "https://github.com/fxbox/taxonomy.git", rev = "8cad391" }
-foxbox_thinkerbell = { git = "https://github.com/fxbox/thinkerbell.git", rev = "ec60634" }
+foxbox_taxonomy = { git = "https://github.com/fxbox/taxonomy.git", rev = "c8f05af" }
+foxbox_thinkerbell = { git = "https://github.com/fxbox/thinkerbell.git", rev = "84a0a30" }
+# foxbox_taxonomy = { path = "../taxonomy" }
+# foxbox_thinkerbell = { path = "../thinkerbell" }
 foxbox_users = { git = "https://github.com/fxbox/users.git", rev = "73e8943" }
 get_if_addrs = "0.3.1"
 hyper = "0.7.2"
@@ -24,6 +26,7 @@ iron-cors = { git = "https://github.com/fxbox/iron-cors.git", rev = "96ede73" }
 libc = "0.2.7"
 log = "0.3"
 mio = { git = "https://github.com/carllerche/mio.git" }
+mime = "*"
 mount = "0.0.10"
 nix = { git = "https://github.com/nix-rust/nix.git", rev = "138080" } # Until 0.5.1 is released
 openssl = "0.7.6"
@@ -51,9 +54,15 @@ version = "0.2.6"
 default-features = true
 features = ["ssl"]
 
+[dependencies.multipart]
+version = "^0.5.0"
+default-features = false
+features = ["iron"]
+
 [dev-dependencies]
 stainless = "0.1.4"
 iron-test = "0.2.0"
 regex = "0.1.55"
 rand = "0.3.14"
 tempdir = "0.3.4"
+

--- a/src/adapters/clock/mod.rs
+++ b/src/adapters/clock/mod.rs
@@ -2,7 +2,7 @@
 //! timestamp or the current time of day.
 
 use foxbox_taxonomy::manager::*;
-use foxbox_taxonomy::api::{ Error, InternalError };
+use foxbox_taxonomy::api::{ Error, InternalError, User };
 use foxbox_taxonomy::values::{ Duration as ValDuration, Range, TimeStamp, Type, Value };
 use foxbox_taxonomy::services::*;
 
@@ -70,7 +70,7 @@ impl Adapter for Clock {
         &ADAPTER_VERSION
     }
 
-    fn fetch_values(&self, mut set: Vec<Id<Getter>>) -> ResultMap<Id<Getter>, Option<Value>, Error> {
+    fn fetch_values(&self, mut set: Vec<Id<Getter>>, _: User) -> ResultMap<Id<Getter>, Option<Value>, Error> {
         set.drain(..).map(|id| {
             if id == self.getter_timestamp_id {
                 let date = TimeStamp::from_datetime(chrono::UTC::now());
@@ -86,7 +86,7 @@ impl Adapter for Clock {
         }).collect()
     }
 
-    fn send_values(&self, mut values: HashMap<Id<Setter>, Value>) -> ResultMap<Id<Setter>, (), Error> {
+    fn send_values(&self, mut values: HashMap<Id<Setter>, Value>, _: User) -> ResultMap<Id<Setter>, (), Error> {
         values.drain()
             .map(|(id, _)| {
                 (id.clone(), Err(Error::InternalError(InternalError::NoSuchSetter(id))))

--- a/src/adapters/ip_camera/mod.rs
+++ b/src/adapters/ip_camera/mod.rs
@@ -11,7 +11,7 @@ extern crate serde_json;
 mod api;
 mod upnp_listener;
 
-use foxbox_taxonomy::api::{Error, InternalError};
+use foxbox_taxonomy::api::{Error, InternalError, User};
 use foxbox_taxonomy::manager::*;
 use foxbox_taxonomy::selector::*;
 use foxbox_taxonomy::services::*;
@@ -191,7 +191,8 @@ impl Adapter for IPCameraAdapter {
     }
 
     fn fetch_values(&self,
-                    mut set: Vec<Id<Getter>>)
+                    mut set: Vec<Id<Getter>>,
+                    _: User)
                     -> ResultMap<Id<Getter>, Option<Value>, Error> {
         set.drain(..).map(|id| {
             let camera = match self.services.lock().unwrap().getters.get(&id) {
@@ -218,7 +219,7 @@ impl Adapter for IPCameraAdapter {
         }).collect()
     }
 
-    fn send_values(&self, mut values: HashMap<Id<Setter>, Value>) -> ResultMap<Id<Setter>, (), Error> {
+    fn send_values(&self, mut values: HashMap<Id<Setter>, Value>, _: User) -> ResultMap<Id<Setter>, (), Error> {
         values.drain().map(|(id, _)| {
             let camera = match self.services.lock().unwrap().setters.get(&id) {
                 Some(camera) => camera.clone(),

--- a/src/adapters/thinkerbell/mod.rs
+++ b/src/adapters/thinkerbell/mod.rs
@@ -1,6 +1,6 @@
 //! An adapter providing access to the Thinkerbell rules engine.
 
-use foxbox_taxonomy::api::{ Error, InternalError };
+use foxbox_taxonomy::api::{ Error, InternalError, User };
 use foxbox_taxonomy::manager::*;
 use foxbox_taxonomy::services::{ Setter, Getter, AdapterId, ServiceId, Service, Channel, ChannelKind };
 use foxbox_taxonomy::util::Id;
@@ -99,7 +99,7 @@ impl Adapter for ThinkerbellAdapter {
         &ADAPTER_VERSION
     }
 
-    fn fetch_values(&self, set: Vec<Id<Getter>>) -> ResultMap<Id<Getter>, Option<Value>, Error> {
+    fn fetch_values(&self, set: Vec<Id<Getter>>, _: User) -> ResultMap<Id<Getter>, Option<Value>, Error> {
         set.iter().map(|id| {
             let (tx, rx) = channel();
             let _ = self.tx.lock().unwrap().send(ThinkAction::RespondToGetter(tx, id.clone()));
@@ -112,7 +112,7 @@ impl Adapter for ThinkerbellAdapter {
         }).collect()
     }
 
-    fn send_values(&self, values: HashMap<Id<Setter>, Value>) -> ResultMap<Id<Setter>, (), Error> {
+    fn send_values(&self, values: HashMap<Id<Setter>, Value>, _: User) -> ResultMap<Id<Setter>, (), Error> {
         values.iter()
             .map(|(id, value)| {
                 let (tx, rx) = channel();

--- a/src/adapters/webpush/mod.rs
+++ b/src/adapters/webpush/mod.rs
@@ -16,7 +16,7 @@
 mod crypto;
 mod db;
 
-use foxbox_taxonomy::api::{ Error, InternalError };
+use foxbox_taxonomy::api::{ Error, InternalError, User };
 use foxbox_taxonomy::manager::*;
 use foxbox_taxonomy::services::*;
 use foxbox_taxonomy::values::{ Range, Type, Value, Json };
@@ -172,7 +172,7 @@ impl<C: Controller> Adapter for WebPush<C> {
         &ADAPTER_VERSION
     }
 
-    fn fetch_values(&self, mut set: Vec<Id<Getter>>) -> ResultMap<Id<Getter>, Option<Value>, Error> {
+    fn fetch_values(&self, mut set: Vec<Id<Getter>>, _: User) -> ResultMap<Id<Getter>, Option<Value>, Error> {
         set.drain(..).map(|id| {
             let user_id = 1; // FIXME: currently logged in user
 
@@ -196,7 +196,7 @@ impl<C: Controller> Adapter for WebPush<C> {
         }).collect()
     }
 
-    fn send_values(&self, mut values: HashMap<Id<Setter>, Value>) -> ResultMap<Id<Setter>, (), Error> {
+    fn send_values(&self, mut values: HashMap<Id<Setter>, Value>, _: User) -> ResultMap<Id<Setter>, (), Error> {
         values.drain().map(|(id, value)| {
             let user_id = 1; // FIXME: currently logged in user
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -38,6 +38,8 @@ extern crate libc;
 #[macro_use]
 extern crate log;
 extern crate mio;
+#[macro_use]
+extern crate mime;
 extern crate mount;
 extern crate nix;
 extern crate openssl;


### PR DESCRIPTION
This patch converts the taxonomy_router to return multipart data when
the result of a fetch (or, theoretically, anything else) contains
Binary.

Other changes were required to get foxbox to compile.

r? @fabricedesre 

Note: Not tested. I need to come up with a test scenario.
