### PR TITLE
Use latest firefox instead of 31.0esr

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,9 @@ cache:
         - node_modules
         - $TRAVIS_BUILD_DIR/target
 
+addons:
+  firefox: latest
+
 # $BOX_HOST_NAME and $BOX_PORT are also used by Selenium tests.
 env:
   - BOX_LOCAL_NAME=foxbox BOX_PORT=3000
@@ -18,12 +21,12 @@ before_install:
   - sudo apt-get install -y avahi-daemon libavahi-client-dev libavahi-common-dev libavahi-common3 libdbus-1-dev libupnp-dev libespeak-dev libudev-dev
   - sudo usermod -a -G netdev $USER # "netdev" group membership allows to set custom host name via avahi-daemon.
   - sudo apt-get install -y libcurl4-openssl-dev libelf-dev libdw-dev # kcov's dependencies
-  
+
 before_script:
     - "sh -e /etc/init.d/xvfb start"
     - "export DISPLAY=:99.0"
-    - "wget http://selenium-release.storage.googleapis.com/2.50/selenium-server-standalone-2.50.1.jar"
-    - "java -jar selenium-server-standalone-2.50.1.jar > /dev/null &"
+    - "wget http://selenium-release.storage.googleapis.com/2.53/selenium-server-standalone-2.53.0.jar"
+    - "java -jar selenium-server-standalone-2.53.0.jar > /dev/null &"
     - sleep 5
     - nvm install 4.2
     - nvm use 4.2

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "devDependencies": {
     "jshint": "2.9.1",
     "mocha": "2.4.5",
-    "selenium-webdriver": "2.48.2",
+    "selenium-webdriver": "2.53.1",
     "chai": "^3.5.0",
     "body-parser": "^1.15.0",
     "should": "^8.2.2",
@@ -37,9 +37,6 @@
     "path": "^0.12.7",
     "config-js": "^1.1.9",
     "express": "^4.13.4",
-    "iso-date": "^1.0.0"
-  },
-  "dependencies": {
     "iso-date": "^1.0.0"
   }
 }


### PR DESCRIPTION
Selenium tests don't pass locally anymore. This is due to Firefox 46+ which doesn't requires addon signin. That's how selenium took control of Firefox. Now we have to use Marionette. This can simply be done by upgrading to the latest Selenium
