### PR TITLE
Prevent cargo from building every time

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,12 @@ name = "foxbox"
 version = "0.1.0"
 authors = ["fabrice <fabrice@desre.org>"]
 build = "build.rs"
-exclude = [ "config/**" ]
+# Files that shouldn't retrigger a new rust build if they are changed
+exclude = [ "config/**", "**/*.conf",
+            "node_modules/**/*", "test/**/*", "tools/**/*", # Non-rust scripts
+            "**/*.log", "**/*.sqlite", # Application generated data
+            "**/*.md", "**/*.yml"      # e.g.: READMEs, Travis
+          ]
 
 [features]
 default = ["authentication"]


### PR DESCRIPTION
When I debugged #313, I noticed cargo was rebuilding nearly every time I ran `npm run test-selenium`. After some investigation, it turned out npm wrote `npm-debug.log` each time tests failed.

Then, in order to optimize the execution time, I propose to stop cargo from building when some file are changed.

r? @ferjm 
