### PR TITLE
Allow ZWave device to come from the configuration.

### DIFF
--- a/src/adapters/mod.rs
+++ b/src/adapters/mod.rs
@@ -69,7 +69,8 @@ impl<T: Controller> AdapterManager<T> {
         let scripts_path = &self.controller.get_profile().path_for("thinkerbell_scripts.sqlite");
         ThinkerbellAdapter::init(manager, scripts_path).unwrap(); // FIXME: no unwrap!
         let profile_openzwave = &self.controller.get_profile().path_for("openzwave");
-        OpenzwaveAdapter::init(manager, profile_openzwave).unwrap();
+        let openzwave_device = self.controller.clone().get_config().get("openzwave", "device");
+        OpenzwaveAdapter::init(manager, profile_openzwave, openzwave_device).unwrap();
 
         self.start_tts(manager);
     }


### PR DESCRIPTION
r? @julienw 

This needs https://github.com/fxbox/openzwave-adapter/pull/24

The user can either provide a command line option:

```
cargo run -- --disable-tls --config 'openzwave;device;/dev/ttyACM0'
```

or they can add an entry to foxbox.conf:

```
{
  "foxbox": {
    "certificate_directory": "certs/"
  },
  "philips_hue": {
    "nupnp_enabled": "true",
    "nupnp_url": "http://www.meethue.com/api/nupnp",
    "token_001788fffe230cda": "f0970f2995fb487eb3a7ec0c7760959c"
  },
  "openzwave": {
    "device": "/dev/ttyACM0"
  }
}
```
