### PR TITLE
Call taxonomy's AdapterManager::stop method, so that adapters' stop m…

### DIFF
--- a/src/controller.rs
+++ b/src/controller.rs
@@ -100,6 +100,7 @@ impl Controller for FoxBox {
 
         debug!("Stopping controller");
         adapter_manager.stop();
+        taxo_manager.stop();
     }
 
     fn adapter_started(&self, adapter: String) {


### PR DESCRIPTION
…ethods are called as well (fixes #387)
