### PR TITLE
Travis: Add optional job to forecast `cargo update` failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,10 +21,12 @@ matrix:
   allow_failures:
     - rust: nightly
   include:
-    - sudo: required
-      os: linux
+    - os: linux
       rust: nightly-2016-04-10
       env: BUILD_ENV=-arm_cross_compile
+    - os: linux
+      rust: nightly
+      env: BUILD_ENV=-cargo_update
 
 addons:
   firefox: latest

--- a/tools/travis-linux-arm_cross_compile.sh
+++ b/tools/travis-linux-arm_cross_compile.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -e
+set -ev
 
 BUILD_TARGET='arm-linux-gnueabihf'
 RUST_TARGET='armv7-unknown-linux-gnueabihf'

--- a/tools/travis-linux-cargo_update.sh
+++ b/tools/travis-linux-cargo_update.sh
@@ -1,0 +1,25 @@
+#/bin/bash
+
+set -ev
+
+CURRENT_PATH="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$CURRENT_PATH/travis-linux-common.sh"
+
+
+build() {
+    echo "build: updating Cargo.lock to the most recent version"
+    cargo update
+    cargo build
+}
+
+lint() {
+    echo "lint: nothing to do. Skipping..."
+}
+
+set_up_tests() {
+    echo "set_up_tests: nothing to do. Skipping..."
+}
+
+run_tests() {
+    echo "run_tests: nothing to do. Skipping..."
+}

--- a/tools/travis-linux-common.sh
+++ b/tools/travis-linux-common.sh
@@ -1,0 +1,7 @@
+install_dependencies() {
+    # Missing dependencies only. The regular ones are in done with the APT addon
+    # defined in .travis.yml
+    sudo apt-get -qq update
+    # TODO: Move to apt addon once https://github.com/travis-ci/apt-package-whitelist/issues/1983 lands
+    sudo apt-get install -y avahi-daemon libavahi-client-dev libavahi-common-dev libdbus-1-dev
+}

--- a/tools/travis-linux.sh
+++ b/tools/travis-linux.sh
@@ -1,16 +1,10 @@
 #/bin/bash
 
-set -e
+set -ev
 
 CURRENT_PATH="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$CURRENT_PATH/travis-linux-common.sh"
 
-install_dependencies() {
-    # Missing dependencies only. The regular ones are in done with the APT addon
-    # defined in .travis.yml
-    sudo apt-get -qq update
-    # TODO: Move to apt addon once https://github.com/travis-ci/apt-package-whitelist/issues/1983 lands
-    sudo apt-get install -y avahi-daemon libavahi-client-dev libavahi-common-dev libdbus-1-dev
-}
 
 build() {
     cargo build

--- a/tools/travis-osx.sh
+++ b/tools/travis-osx.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -e
+set -ev
 
 CURRENT_PATH="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 


### PR DESCRIPTION
For reference:
- Example of [failed job](https://travis-ci.org/fxbox/foxbox/jobs/125009235)

Fixes #409. Depends on #411 
