### PR TITLE
Fix most build warnings in openzwave-adapter

### DIFF
--- a/components/openzwave-adapter/src/id_map.rs
+++ b/components/openzwave-adapter/src/id_map.rs
@@ -1,0 +1,33 @@
+use taxonomy::util::Id as TaxoId;
+
+use std::sync::{ Arc, RwLock };
+
+#[derive(Debug, Clone)]
+pub struct IdMap<Kind, Type> {
+    map: Arc<RwLock<Vec<(TaxoId<Kind>, Type)>>>
+}
+
+impl<Kind, Type> IdMap<Kind, Type> where Type: Eq + Clone, Kind: Clone {
+    pub fn new() -> Self {
+        IdMap {
+            map: Arc::new(RwLock::new(Vec::new()))
+        }
+    }
+
+    pub fn push(&mut self, id: TaxoId<Kind>, ozw_object: Type) {
+        let mut guard = self.map.write().unwrap(); // we have bigger problems if we're poisoned
+        guard.push((id, ozw_object));
+    }
+
+    pub fn find_tax_id_from_ozw(&self, needle: &Type) -> Option<TaxoId<Kind>> {
+        let guard = self.map.read().unwrap(); // we have bigger problems if we're poisoned
+        let find_result = guard.iter().find(|&&(_, ref item)| item == needle);
+        find_result.map(|&(ref id, _)| id.clone())
+    }
+
+    pub fn find_ozw_from_tax_id(&self, needle: &TaxoId<Kind>) -> Option<Type> {
+        let guard = self.map.read().unwrap(); // we have bigger problems if we're poisoned
+        let find_result = guard.iter().find(|&&(ref id, _)| id == needle);
+        find_result.map(|&(_, ref ozw_object)| ozw_object.clone())
+    }
+}


### PR DESCRIPTION
- convert results wherever it makes sense
- extract IdMap into its own file
- use unwrap() for IdMap's locks which allows to simplify its API
- Write error logs for each result that we cannot handle (in the notification callback)
