### PR TITLE
Call "preventDefault()" for the submit buttons at login and signup pages. r=fabrice

### DIFF
--- a/static/main/js/session_ui.js
+++ b/static/main/js/session_ui.js
@@ -114,7 +114,9 @@ var SessionUI = {
     this.loadElements(screen);
   },
 
-  signin: function() {
+  signin: function(evt) {
+    evt.preventDefault();
+
     var pwd = SessionUI.elements.signinPwd.value;
     if (!pwd || pwd.length < 8) {
       window.alert('Invalid password');

--- a/static/setup/js/setup.js
+++ b/static/setup/js/setup.js
@@ -32,7 +32,9 @@ var SetupUI = {
     SetupUI.elements.signupButton.addEventListener('click', SetupUI.signup);
   },
 
-  signup: function() {
+  signup: function(evt) {
+    evt.preventDefault();
+
     var pwd = SetupUI.elements.signupPwd1.value;
     if (pwd != SetupUI.elements.signupPwd2.value) {
       window.alert('Passwords don\'t match! Please try again.');


### PR DESCRIPTION
Default type for the buttons is `submit` but actual submit is performed in JS via XHR, so the easiest fix is to prevent default behavior for submit button.
