### PR TITLE
Travis: Remove unused cache (prone to intermittent failures)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,12 +26,6 @@ matrix:
       rust: nightly-2016-04-10
       env: BUILD_ENV=-arm_cross_compile
 
-cache:
-  directories:
-    - $HOME/.cargo
-    - node_modules
-    - $TRAVIS_BUILD_DIR/target
-
 addons:
   firefox: latest
   apt:

--- a/tools/travis-linux-arm_cross_compile.sh
+++ b/tools/travis-linux-arm_cross_compile.sh
@@ -28,7 +28,18 @@ EOF
         libudev-dev:armhf libavahi-client-dev:armhf libsqlite3-dev:armhf
 }
 
+_set_up_cargo_config() {
+    mkdir -p "$HOME/.cargo"
+    touch "$HOME/.cargo/config"
+    tee -a "$HOME/.cargo/config" << EOF
+[target.$RUST_TARGET]
+linker = "$BUILD_TARGET-gcc"
+EOF
+}
+
 _set_up_environment() {
+    _set_up_cargo_config
+
     # open-zwave wants -cc and -c++ but no package seems to provid them.
     sudo cp "/usr/bin/$BUILD_TARGET-gcc" "/usr/bin/$BUILD_TARGET-cc"
     sudo cp "/usr/bin/$BUILD_TARGET-g++" "/usr/bin/$BUILD_TARGET-c++"
@@ -38,11 +49,6 @@ _set_up_environment() {
 
     # For open-zwave
     export CROSS_COMPILE="$BUILD_TARGET-"
-
-    tee -a $HOME/.cargo/config << EOF
-[target.$RUST_TARGET]
-linker = "$BUILD_TARGET-gcc"
-EOF
 
     export PKG_CONFIG_LIBDIR="/usr/lib/$BUILD_TARGET/pkgconfig"
     export PKG_CONFIG_ALLOW_CROSS=1


### PR DESCRIPTION
Today, @isabelrios noticed a [job that was marked as failed](https://travis-ci.org/fxbox/foxbox/jobs/126315207), even though every step passed. Based on this [comment in travis-ci's issues](https://github.com/travis-ci/travis-ci/issues/5120#issuecomment-157026545), we might face unlogged cache failures. 

This kind of error is usually not a problem, unless our shell scripts toggle `set -e` (and [we do here](https://github.com/fxbox/foxbox/blob/1aaa8395e53ce58fbcc94eed1bfc0b1e7f480d4b/tools/travis-osx.sh#L3), for instance).

After looking up the documentation, we actually [don't use the cache anymore](https://docs.travis-ci.com/user/ci-environment/). It started when we had to move away from the container infrastructure. [Like said here](https://github.com/fxbox/foxbox/issues/410#issuecomment-215137562), we won't be able to go back to containers until a few more months.

Consequently, I propose to save some CPU time and make the jobs stronger by just removing the cache.

r? @fabricedesre 
