### PR TITLE
Logging tags database name to debug log

### DIFF
--- a/components/taxonomy/src/tag_storage.rs
+++ b/components/taxonomy/src/tag_storage.rs
@@ -48,7 +48,7 @@ impl TagStorage {
             return;
         }
 
-        info!("Opening taxonomy tags database at {}", self.path.display());
+        debug!("Opening taxonomy tags database at {}", self.path.display());
         let db = Connection::open(self.path.clone()).unwrap_or_else(|err| {
             panic!("Unable to open taxonomy tags database: {}", err);
         });


### PR DESCRIPTION
I'm seeing four INFO log lines regarding the `taxonomy tags database` per light service on my system, that looks like one log line per setter or getter. I propose to take this irrelevant info out of user view by diverting it to the debug log.
