### PR TITLE
Use https url for the Hue nupnp server

### DIFF
--- a/src/adapters/philips_hue/discovery.rs
+++ b/src/adapters/philips_hue/discovery.rs
@@ -54,7 +54,7 @@ impl<C: Controller> Discovery<C> {
                 "philips_hue", "nupnp_enabled", "true");
             if nupnp_enabled == "true" {
                 let nupnp_url = controller.get_config().get_or_set_default(
-                    "philips_hue", "nupnp_url", "http://www.meethue.com/api/nupnp");
+                    "philips_hue", "nupnp_url", "https://www.meethue.com/api/nupnp");
                 let nupnp_hubs = nupnp_query(&nupnp_url);
                 for nupnp in nupnp_hubs {
                     let _ = tx.lock().unwrap().send(HueAction::AddHub(nupnp.id.to_owned(),

--- a/src/adapters/philips_hue/http.rs
+++ b/src/adapters/philips_hue/http.rs
@@ -51,7 +51,7 @@ pub fn put(url: &str, data: &str) -> Result<String, Box<Error>> {
 describe! philips_hue_http {
 
     before_each {
-        let good_url = "http://www.meethue.com/api/nupnp";
+        let good_url = "https://www.meethue.com/api/nupnp";
     }
 
     // TODO: This test fails on travis (not locally) for unknown reasons:


### PR DESCRIPTION
That's saving us a http redirect.

r? @cr 
