### PR TITLE
Refactor so Backoff is separate from the ManagedProcess

### DIFF
--- a/src/utils.rs
+++ b/src/utils.rs
@@ -73,6 +73,17 @@ macro_rules! current_dir {
     };
 }
 
+macro_rules! checklock (
+    ($e: expr) => {
+        match $e {
+            Ok(guard) => guard,
+            Err(poisoned) => {
+                warn!("lock was poisoned - using anyway..");
+                poisoned.into_inner()
+            },
+        }
+    }
+);
 
 #[cfg(test)]
 #[macro_use]


### PR DESCRIPTION
- Add an API to retrieve number of times the process has restarted (useful for testing, will possibly follow up with #99)
- Small change to avoid fatals in weird conditions from libc (reactivated test: see #354)
- Added `checklock!` macro, to check and force poisoned locks.

This is in preparation for a managed process that isn't spawned with a command, but instead spawned from a closure (using `libc::fork`).

r? @fabricedesre 
