### PR TITLE
Decentralizing: Introducing supports_*

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,8 +21,8 @@ dependencies = [
  "mount 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "multicast_dns 0.1.0 (git+https://github.com/fxbox/multicast-dns.git?rev=a6e4bcc)",
  "nix 0.5.1-pre (git+https://github.com/nix-rust/nix.git?rev=138080)",
- "openssl 0.7.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "openssl-sys 0.7.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "openssl 0.7.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "openssl-sys 0.7.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "openzwave-adapter 0.1.0",
  "pkg-config 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -45,7 +45,7 @@ dependencies = [
  "url 0.5.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "ws 0.4.6 (git+https://github.com/JohanLorenzo/ws-rs.git?branch=0.4.6)",
- "xml-rs 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "xml-rs 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -147,7 +147,7 @@ name = "cookie"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "openssl 0.7.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "openssl 0.7.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -258,7 +258,7 @@ name = "gdi32-sys"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "winapi 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -295,7 +295,7 @@ dependencies = [
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "mime 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "num_cpus 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "openssl 0.7.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "openssl 0.7.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "solicit 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -382,7 +382,7 @@ name = "kernel32-sys"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "winapi 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -467,7 +467,7 @@ dependencies = [
  "nix 0.5.0-pre (git+https://github.com/carllerche/nix-rust?rev=c4257f8a76)",
  "slab 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -477,7 +477,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "net2 0.2.23 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "ws2_32-sys 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -520,7 +520,7 @@ dependencies = [
  "cfg-if 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "ws2_32-sys 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -545,7 +545,7 @@ dependencies = [
 
 [[package]]
 name = "nom"
-version = "1.2.2"
+version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -590,20 +590,20 @@ dependencies = [
 
 [[package]]
 name = "openssl"
-version = "0.7.10"
+version = "0.7.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "bitflags 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitflags 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "gcc 0.3.28 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "openssl-sys 0.7.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "openssl-sys-extras 0.7.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "openssl-sys 0.7.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "openssl-sys-extras 0.7.11 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "openssl-sys"
-version = "0.7.10"
+version = "0.7.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "gdi32-sys 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -615,12 +615,12 @@ dependencies = [
 
 [[package]]
 name = "openssl-sys-extras"
-version = "0.7.10"
+version = "0.7.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "gcc 0.3.28 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "openssl-sys 0.7.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "openssl-sys 0.7.11 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -824,7 +824,7 @@ name = "semver"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "nom 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "nom 1.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -957,7 +957,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -977,8 +977,8 @@ dependencies = [
  "iron 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "mktemp 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "openssl 0.7.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "openssl-sys 0.7.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "openssl 0.7.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "openssl-sys 0.7.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_macros 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1104,7 +1104,7 @@ name = "user32-sys"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "winapi 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1137,7 +1137,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "winapi"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -1164,13 +1164,13 @@ name = "ws2_32-sys"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "winapi 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "xml-rs"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bitflags 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/components/taxonomy/src/adapter.rs
+++ b/components/taxonomy/src/adapter.rs
@@ -60,8 +60,8 @@ pub trait AdapterManagerHandle: Send {
     /// cleanup before returning an error.
     fn remove_service(& self, service_id: &Id<ServiceId>) -> Result<(), Error>;
 
-    /// Add a setter to the system. Typically, this is called by the adapter when a new
-    /// service has been detected/configured. Some services may gain/lose getters at
+    /// Add a channel to the system. Typically, this is called by the adapter when a new
+    /// service has been detected/configured. Some services may gain/lose channels at
     /// runtime depending on their configuration.
     ///
     /// # Requirements
@@ -73,7 +73,7 @@ pub trait AdapterManagerHandle: Send {
     /// Returns an error if the adapter is not registered, the parent service is not
     /// registered, or a channel with the same identifier is already registered.
     /// In either cases, this method reverts all its changes.
-    fn add_getter(& self, setter: Channel) -> Result<(), Error>;
+    fn add_channel(& self, setter: Channel) -> Result<(), Error>;
 
     /// Remove a setter previously registered on the system. Typically, called by
     /// an adapter when a service is reconfigured to remove one of its getters.
@@ -83,32 +83,7 @@ pub trait AdapterManagerHandle: Send {
     /// This method returns an error if the setter is not registered or if the service
     /// is not registered. In either case, it attemps to clean as much as possible, even
     /// if the state is inconsistent.
-    fn remove_getter(& self, id: &Id<Channel>) -> Result<(), Error>;
-
-    /// Add a setter to the system. Typically, this is called by the adapter when a new
-    /// service has been detected/configured. Some services may gain/lose setters at
-    /// runtime depending on their configuration.
-    ///
-    /// # Requirements
-    ///
-    /// The adapter is in charge of making sure that identifiers persist across reboots.
-    ///
-    /// # Errors
-    ///
-    /// Returns an error if the adapter is not registered, the parent service is not
-    /// registered, or a channel with the same identifier is already registered.
-    /// In either cases, this method reverts all its changes.
-    fn add_setter(& self, setter: Channel) -> Result<(), Error>;
-
-    /// Remove a setter previously registered on the system. Typically, called by
-    /// an adapter when a service is reconfigured to remove one of its setters.
-    ///
-    /// # Error
-    ///
-    /// This method returns an error if the setter is not registered or if the service
-    /// is not registered. In either case, it attemps to clean as much as possible, even
-    /// if the state is inconsistent.
-    fn remove_setter(& self, id: &Id<Channel>) -> Result<(), Error>;
+    fn remove_channel(& self, id: &Id<Channel>) -> Result<(), Error>;
 }
 
 pub enum WatchEvent {

--- a/components/taxonomy/src/api.rs
+++ b/components/taxonomy/src/api.rs
@@ -417,63 +417,9 @@ pub trait API: Send {
     /// A JSON string representing a number.
     fn remove_service_tags(& self, selectors: Vec<ServiceSelector>, tags: Vec<Id<TagId>>) -> usize;
 
-    /// Get a list of getters matching some conditions
-    ///
-    /// # REST API
-    ///
-    /// `GET /api/v1/channels/getters`
-    ///
-    /// ### JSON
-    ///
-    /// This call accepts as JSON argument a vector of `ChannelSelector`. See the documentation
-    /// of `ChannelSelector` for more details.
-    ///
-    /// Example: Select all doors in the entrance (tags `door`, `entrance`)
-    /// that support setter channel `OpenClosed`
-    ///
-    /// ```
-    /// # use foxbox_taxonomy::selector::*;
-    ///
-    /// let source = r#"[{
-    ///   "tags": ["entrance", "door"],
-    ///   "kind": "OpenClosed"
-    /// }]"#;
-    ///
-    /// # Vec::<ChannelSelector>::from_str(&source).unwrap();
-    /// ```
-    ///
-    ///
-    /// ## Errors
-    ///
-    /// In case of syntax error, Error 400, accompanied with a
-    /// somewhat human-readable JSON string detailing the error.
-    ///
-    /// ## Success
-    ///
-    /// A JSON representing an array of `Service`. See the implementation
-    /// of `Service` for details.
-    ///
-    /// ### Example
-    ///
-    /// ```
-    /// # let source =
-    /// r#"[{
-    ///   "tags": ["entrance", "door", "somevendor"],
-    ///   "id: "some-getter-id",
-    ///   "service": "some-service-id",
-    ///   "updated": "2014-11-28T12:00:09+00:00",
-    ///   "mechanism": "getter",
-    ///   "kind": "OnOff"
-    /// }]"#;
-    /// ```
-    fn get_getter_channels(& self, selectors: Vec<ChannelSelector>) -> Vec<Channel>;
 
-    /// Get a list of getters matching some conditions
-    ///
-    /// # REST API
-    ///
-    /// `GET /api/v1/channels`
-    fn get_setter_channels(& self, selectors: Vec<ChannelSelector>) -> Vec<Channel>;
+    /// Get a list of channels matching some conditions
+    fn get_channels(& self, selectors: Vec<ChannelSelector>) -> Vec<Channel>;
 
     /// Label a set of channels with a set of tags.
     ///
@@ -519,8 +465,7 @@ pub trait API: Send {
     /// ## Success
     ///
     /// A JSON representing a number.
-    fn add_getter_tags(& self, selectors: Vec<ChannelSelector>, tags: Vec<Id<TagId>>) -> usize;
-    fn add_setter_tags(& self, selectors: Vec<ChannelSelector>, tags: Vec<Id<TagId>>) -> usize;
+    fn add_channel_tags(& self, selectors: Vec<ChannelSelector>, tags: Vec<Id<TagId>>) -> usize;
 
     /// Remove a set of tags from a set of channels.
     ///
@@ -566,8 +511,7 @@ pub trait API: Send {
     /// ## Success
     ///
     /// A JSON representing a number.
-    fn remove_getter_tags(& self, selectors: Vec<ChannelSelector>, tags: Vec<Id<TagId>>) -> usize;
-    fn remove_setter_tags(& self, selectors: Vec<ChannelSelector>, tags: Vec<Id<TagId>>) -> usize;
+    fn remove_channel_tags(& self, selectors: Vec<ChannelSelector>, tags: Vec<Id<TagId>>) -> usize;
 
     /// Read the latest value from a set of channels
     ///

--- a/components/thinkerbell/src/compile.rs
+++ b/components/thinkerbell/src/compile.rs
@@ -21,6 +21,7 @@ use ast::{ Script, Rule, Statement, Match, Context, UncheckedCtx };
 use util::*;
 
 use foxbox_taxonomy::api::API;
+use foxbox_taxonomy::util::Exactly;
 use foxbox_taxonomy::values::Duration;
 
 use transformable_channels::mpsc::*;
@@ -167,7 +168,8 @@ impl<Env> Compiler<Env> where Env: ExecutableDevEnv {
         let source = match_.source
             .iter()
             .map(|input| input.clone()
-                 .with_kind(match_.kind.clone()))
+                 .with_kind(match_.kind.clone())
+                 .with_supports_watch(Exactly::Exactly(true)))
             .collect();
         Ok(Match {
             source: source,

--- a/components/thinkerbell/src/fake_env.rs
+++ b/components/thinkerbell/src/fake_env.rs
@@ -480,30 +480,16 @@ impl FakeEnv {
                 }
                 let _ = self.on_event.send(FakeEnvEvent::Done);
             },
-            AddGetters(vec) => {
-                for getter in vec {
-                    let result = self.manager.add_getter(getter);
+            AddChannels(vec) => {
+                for channel in vec {
+                    let result = self.manager.add_channel(channel);
                     self.report_error(result);
                 }
                 let _ = self.on_event.send(FakeEnvEvent::Done);
             },
-            RemoveGetters(vec) => {
-                for getter in vec {
-                    let result = self.manager.remove_getter(&getter);
-                    self.report_error(result);
-                }
-                let _ = self.on_event.send(FakeEnvEvent::Done);
-            },
-            AddSetters(vec) => {
-                for setter in vec {
-                    let result = self.manager.add_setter(setter);
-                    self.report_error(result);
-                }
-                let _ = self.on_event.send(FakeEnvEvent::Done);
-            },
-            RemoveSetters(vec) => {
-                for setter in vec {
-                    let result = self.manager.remove_setter(&setter);
+            RemoveChannels(vec) => {
+                for channel in vec {
+                    let result = self.manager.remove_channel(&channel);
                     self.report_error(result);
                 }
                 let _ = self.on_event.send(FakeEnvEvent::Done);
@@ -540,10 +526,8 @@ impl Deserialize for FakeEnv {
 pub enum Instruction {
     AddAdapters(Vec<String>),
     AddServices(Vec<Service>),
-    AddGetters(Vec<Channel>),
-    AddSetters(Vec<Channel>),
-    RemoveGetters(Vec<Id<Channel>>),
-    RemoveSetters(Vec<Id<Channel>>),
+    AddChannels(Vec<Channel>),
+    RemoveChannels(Vec<Id<Channel>>),
     InjectGetterValues(Vec<(Id<Channel>, Result<Value, Error>)>),
     InjectSetterErrors(Vec<(Id<Channel>, Option<Error>)>),
     TriggerTimersUntil(TimeStamp),

--- a/components/thinkerbell/src/run.rs
+++ b/components/thinkerbell/src/run.rs
@@ -258,9 +258,9 @@ impl<Env> ExecutionTask<Env> where Env: ExecutableDevEnv + Debug {
                 // (which we should eventually optimize, if we find
                 // out that we end up with large rulesets).
 
-                let getters = api.get_getter_channels(condition.source.clone());
+                let channels = api.get_channels(condition.source.clone());
                 info!("[Recipe '{}'] Initializing rule {} condition {}. Currently, it can listen to {} channels.", self.script.name,
-                    rule_index, condition_index, getters.len());
+                    rule_index, condition_index, channels.len());
 
                 let rule_index = rule_index.clone();
                 let condition_index = condition_index.clone();

--- a/components/thinkerbell/tests/test_rules.rs
+++ b/components/thinkerbell/tests/test_rules.rs
@@ -17,7 +17,7 @@ use foxbox_taxonomy::values::{ Duration, OnOff, Range, TimeStamp, Type, TypeErro
 use std::fmt::Debug;
 use std::marker::PhantomData;
 use std::thread;
-use std::collections::{ HashMap, HashSet };
+use std::collections::HashMap;
 
 use transformable_channels::mpsc::*;
 
@@ -140,35 +140,25 @@ fn test_run() {
     rx_done.recv().unwrap();
 
     env.execute(Instruction::AddServices(vec![
-        Service {
-            id: service_id_1.clone(),
-            adapter: adapter_id_1.clone(),
-            getters: HashMap::new(),
-            setters: HashMap::new(),
-            tags: HashSet::new(),
-            properties: HashMap::new(),
+        Service::empty(&service_id_1, &adapter_id_1)
+    ]));
+    rx_done.recv().unwrap();
+
+    env.execute(Instruction::AddChannels(vec![
+        Channel {
+            kind: ChannelKind::LightOn,
+            supports_fetch: true,
+            supports_watch: true,
+            .. Channel::empty(&getter_id_1, &service_id_1, &adapter_id_1)
         }
     ]));
     rx_done.recv().unwrap();
 
-    env.execute(Instruction::AddGetters(vec![
+    env.execute(Instruction::AddChannels(vec![
         Channel {
-            id: getter_id_1.clone(),
-            adapter: adapter_id_1.clone(),
-            service: service_id_1.clone(),
-            tags: HashSet::new(),
             kind: ChannelKind::LightOn,
-        }
-    ]));
-    rx_done.recv().unwrap();
-
-    env.execute(Instruction::AddSetters(vec![
-        Channel {
-            id: setter_id_1.clone(),
-            adapter: adapter_id_1.clone(),
-            service: service_id_1.clone(),
-            tags: HashSet::new(),
-            kind: ChannelKind::LightOn,
+            supports_send: true,
+            .. Channel::empty(&setter_id_1, &service_id_1, &adapter_id_1)
         }
     ]));
     rx_done.recv().unwrap();
@@ -213,13 +203,12 @@ fn test_run() {
     assert_eq!(value, Value::OnOff(OnOff::Off));
 
     println!("* Adding a second getter doesn't break the world.");
-    env.execute(Instruction::AddGetters(vec![
+    env.execute(Instruction::AddChannels(vec![
         Channel {
-            id: getter_id_2.clone(),
-            adapter: adapter_id_1.clone(),
-            service: service_id_1.clone(),
-            tags: HashSet::new(),
             kind: ChannelKind::LightOn,
+            supports_fetch: true,
+            supports_watch: true,
+            .. Channel::empty(&getter_id_2, &service_id_1, &adapter_id_1)
         }
     ]));
     rx_done.recv().unwrap();
@@ -298,13 +287,11 @@ fn test_run() {
     assert_eq!(value, Value::OnOff(OnOff::Off));
 
     println!("* If we add a second setter, it also receives these sends.");
-    env.execute(Instruction::AddSetters(vec![
+    env.execute(Instruction::AddChannels(vec![
         Channel {
-            id: setter_id_2.clone(),
-            adapter: adapter_id_1.clone(),
-            service: service_id_1.clone(),
-            tags: HashSet::new(),
             kind: ChannelKind::LightOn,
+            supports_send: true,
+            .. Channel::empty(&setter_id_2, &service_id_1, &adapter_id_1)
         }
     ]));
     rx_done.recv().unwrap();
@@ -330,13 +317,11 @@ fn test_run() {
     rx_send.try_recv().unwrap_err();
 
     println!("* If we add a setter of a mismatched type, it does not receive these sends.");
-    env.execute(Instruction::AddSetters(vec![
+    env.execute(Instruction::AddChannels(vec![
         Channel {
-            id: setter_id_3.clone(),
-            adapter: adapter_id_1.clone(),
-            service: service_id_1.clone(),
-            tags: HashSet::new(),
             kind: ChannelKind::Ready,
+            supports_send: true,
+            .. Channel::empty(&setter_id_3, &service_id_1, &adapter_id_1)
         }
     ]));
     rx_done.recv().unwrap();
@@ -362,7 +347,7 @@ fn test_run() {
     rx_send.try_recv().unwrap_err();
 
     println!("* Removing a getter resets its condition_is_met to false.");
-    env.execute(Instruction::RemoveGetters(vec![
+    env.execute(Instruction::RemoveChannels(vec![
         getter_id_1.clone()
     ]));
     rx_done.recv().unwrap();
@@ -388,7 +373,7 @@ fn test_run() {
     rx_send.try_recv().unwrap_err();
 
     println!("* Removing a setter does not prevent the other setter from receiving.");
-    env.execute(Instruction::RemoveSetters(vec![
+    env.execute(Instruction::RemoveChannels(vec![
         setter_id_1.clone()
     ]));
     rx_done.recv().unwrap();
@@ -411,13 +396,11 @@ fn test_run() {
     rx_send.try_recv().unwrap_err();
 
     println!("* Even if a setter has errors, other setters will receive the send.");
-    env.execute(Instruction::AddSetters(vec![
+    env.execute(Instruction::AddChannels(vec![
         Channel {
-            id: setter_id_1.clone(),
-            adapter: adapter_id_1.clone(),
-            service: service_id_1.clone(),
-            tags: HashSet::new(),
             kind: ChannelKind::LightOn,
+            supports_send: true,
+            .. Channel::empty(&setter_id_1, &service_id_1, &adapter_id_1)
         }
     ]));
     rx_done.recv().unwrap();
@@ -541,35 +524,25 @@ fn test_run_with_delay() {
     rx_done.recv().unwrap();
 
     env.execute(Instruction::AddServices(vec![
-        Service {
-            id: service_id_1.clone(),
-            adapter: adapter_id_1.clone(),
-            getters: HashMap::new(),
-            setters: HashMap::new(),
-            tags: HashSet::new(),
-            properties: HashMap::new(),
+        Service::empty(&service_id_1, &adapter_id_1)
+    ]));
+    rx_done.recv().unwrap();
+
+    env.execute(Instruction::AddChannels(vec![
+        Channel {
+            kind: ChannelKind::LightOn,
+            supports_fetch: true,
+            supports_watch: true,
+            .. Channel::empty(&getter_id_1, &service_id_1, &adapter_id_1)
         }
     ]));
     rx_done.recv().unwrap();
 
-    env.execute(Instruction::AddGetters(vec![
+    env.execute(Instruction::AddChannels(vec![
         Channel {
-            id: getter_id_1.clone(),
-            adapter: adapter_id_1.clone(),
-            service: service_id_1.clone(),
-            tags: HashSet::new(),
             kind: ChannelKind::LightOn,
-        }
-    ]));
-    rx_done.recv().unwrap();
-
-    env.execute(Instruction::AddSetters(vec![
-        Channel {
-            id: setter_id_1.clone(),
-            adapter: adapter_id_1.clone(),
-            service: service_id_1.clone(),
-            tags: HashSet::new(),
-            kind: ChannelKind::LightOn,
+            supports_send: true,
+            .. Channel::empty(&setter_id_1, &service_id_1, &adapter_id_1)
         }
     ]));
     rx_done.recv().unwrap();
@@ -652,7 +625,7 @@ fn test_run_with_delay() {
     env.execute(Instruction::TriggerTimersUntil(TimeStamp::from(UTC::now() + ChronoDuration::seconds(2))));
     rx_done.recv().unwrap();
 
-    env.execute(Instruction::RemoveGetters(vec![
+    env.execute(Instruction::RemoveChannels(vec![
         getter_id_1.clone()
     ]));
     rx_done.recv().unwrap();
@@ -680,13 +653,12 @@ fn test_run_with_delay() {
     env.execute(Instruction::ResetTimers);
     rx_done.recv().unwrap();
 
-    env.execute(Instruction::AddGetters(vec![
+    env.execute(Instruction::AddChannels(vec![
         Channel {
-            id: getter_id_1.clone(),
-            adapter: adapter_id_1.clone(),
-            service: service_id_1.clone(),
-            tags: HashSet::new(),
             kind: ChannelKind::LightOn,
+            supports_fetch: true,
+            supports_watch: true,
+            .. Channel::empty(&getter_id_1, &service_id_1, &adapter_id_1)
         }
     ]));
     rx_done.recv().unwrap();

--- a/src/adapters/console/mod.rs
+++ b/src/adapters/console/mod.rs
@@ -9,7 +9,7 @@ use foxbox_taxonomy::values::{ Value };
 
 use transformable_channels::mpsc::*;
 
-use std::collections::{ HashMap, HashSet };
+use std::collections::HashMap;
 use std::sync::Arc;
 
 
@@ -88,19 +88,18 @@ impl Console {
     pub fn init(adapt: &Arc<AdapterManager>) -> Result<(), Error> {
         let service_console_id = Console::service_console_id();
         let setter_stdout_id = Console::setter_stdout_id();
+        let adapter_id = Console::id();
         let console = Arc::new(Console {
             setter_stdout_id: setter_stdout_id.clone()
         });
         try!(adapt.add_adapter(console));
-        let mut service = Service::empty(service_console_id.clone(), Console::id());
+        let mut service = Service::empty(&service_console_id, &adapter_id);
         service.properties.insert("model".to_owned(), "Mozilla console v1".to_owned());
         try!(adapt.add_service(service));
-        try!(adapt.add_setter(Channel {
-                tags: HashSet::new(),
-                adapter: Console::id(),
-                id: setter_stdout_id.clone(),
-                service: service_console_id.clone(),
-                kind: ChannelKind::Log,
+        try!(adapt.add_channel(Channel {
+            kind: ChannelKind::Log,
+            supports_send: true,
+            ..Channel::empty(&setter_stdout_id, &service_console_id, &adapter_id)
         }));
         Ok(())
     }

--- a/src/adapters/ip_camera/mod.rs
+++ b/src/adapters/ip_camera/mod.rs
@@ -21,7 +21,7 @@ use traits::Controller;
 use transformable_channels::mpsc::*;
 use self::api::*;
 use self::upnp_listener::IpCameraUpnpListener;
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 
 const CUSTOM_PROPERTY_MANUFACTURER: &'static str = "manufacturer";
@@ -84,7 +84,7 @@ impl IPCameraAdapter {
         let service_id = create_service_id(udn);
 
         let adapter_id = Self::id();
-        let mut service = Service::empty(service_id.clone(), adapter_id.clone());
+        let mut service = Service::empty(&service_id, &adapter_id);
 
         service.properties.insert(CUSTOM_PROPERTY_MANUFACTURER.to_owned(),
                                            manufacturer.to_owned());
@@ -117,76 +117,62 @@ impl IPCameraAdapter {
               name);
 
         let getter_image_list_id = create_getter_id("image_list", udn);
-        try!(adapt.add_getter(Channel {
-            tags: HashSet::new(),
-            adapter: adapter_id.clone(),
-            id: getter_image_list_id.clone(),
-            service: service_id.clone(),
+        try!(adapt.add_channel(Channel {
+            supports_fetch: true,
             kind: ChannelKind::Extension {
                 vendor: Id::new("foxlink@mozilla.com"),
                 adapter: Id::new("IPCam Adapter"),
                 kind: Id::new("image_list"),
                 typ: Type::Json,
             },
+            ..Channel::empty(&getter_image_list_id, &service_id, &adapter_id)
         }));
 
         let getter_image_newest_id = create_getter_id("image_newest", udn);
-        try!(adapt.add_getter(Channel {
-            tags: HashSet::new(),
-            adapter: adapter_id.clone(),
-            id: getter_image_newest_id.clone(),
-            service: service_id.clone(),
+        try!(adapt.add_channel(Channel {
+            supports_fetch: true,
             kind: ChannelKind::Extension {
                 vendor: Id::new("foxlink@mozilla.com"),
                 adapter: Id::new("IPCam Adapter"),
                 kind: Id::new("latest image"),
                 typ: Type::Binary,
             },
+            ..Channel::empty(&getter_image_newest_id, &service_id, &adapter_id)
         }));
 
         let setter_snapshot_id = create_setter_id("snapshot", udn);
-        try!(adapt.add_setter(Channel {
-            tags: HashSet::new(),
-            adapter: adapter_id.clone(),
-            id: setter_snapshot_id.clone(),
-            service: service_id.clone(),
+        try!(adapt.add_channel(Channel {
+            supports_send: true,
             kind: ChannelKind::TakeSnapshot,
+            ..Channel::empty(&setter_snapshot_id, &service_id, &adapter_id)
         }));
 
         let getter_username_id = create_getter_id("username", udn);
-        try!(adapt.add_getter(Channel {
-            tags: HashSet::new(),
-            adapter: adapter_id.clone(),
-            id: getter_username_id.clone(),
-            service: service_id.clone(),
+        try!(adapt.add_channel(Channel {
+            supports_fetch: true,
             kind: ChannelKind::Username,
+            ..Channel::empty(&getter_username_id, &service_id, &adapter_id)
         }));
 
         let setter_username_id = create_setter_id("username", udn);
-        try!(adapt.add_setter(Channel {
-            tags: HashSet::new(),
-            adapter: adapter_id.clone(),
-            id: setter_username_id.clone(),
-            service: service_id.clone(),
+        try!(adapt.add_channel(Channel {
+            supports_send: true,
             kind: ChannelKind::Username,
+            ..Channel::empty(&setter_username_id, &service_id, &adapter_id)
         }));
 
         let getter_password_id = create_getter_id("password", udn);
-        try!(adapt.add_getter(Channel {
-            tags: HashSet::new(),
-            adapter: adapter_id.clone(),
-            id: getter_password_id.clone(),
-            service: service_id.clone(),
+        try!(adapt.add_channel(Channel {
+            supports_fetch: true,
             kind: ChannelKind::Password,
+            ..Channel::empty(&getter_password_id, &service_id, &adapter_id)
         }));
 
         let setter_password_id = create_setter_id("password", udn);
-        try!(adapt.add_setter(Channel {
-            tags: HashSet::new(),
-            adapter: adapter_id.clone(),
-            id: setter_password_id.clone(),
-            service: service_id.clone(),
+        try!(adapt.add_channel(Channel {
+            supports_send: true,
             kind: ChannelKind::Password,
+            ..Channel::empty(&setter_password_id, &service_id, &adapter_id)
         }));
 
         let mut serv = services.lock().unwrap();

--- a/src/adapters/philips_hue/lights.rs
+++ b/src/adapters/philips_hue/lights.rs
@@ -14,7 +14,6 @@ use foxbox_taxonomy::services::*;
 use foxbox_taxonomy::values::{ Type };
 use super::*;
 use super::hub_api::HubApi;
-use std::collections::HashSet;
 use std::sync::{ Arc, Mutex };
 
 const CUSTOM_PROPERTY_MANUFACTURER: &'static str = "manufacturer";
@@ -68,7 +67,7 @@ impl Light {
             info!("New Philips Hue `Extended Color Light` service for light {} on bridge {}",
                 self.light_id, self.hub_id);
 
-            let mut service = Service::empty(self.service_id.clone(), adapter_id.clone());
+            let mut service = Service::empty(&self.service_id, &adapter_id);
             service.properties.insert(CUSTOM_PROPERTY_MANUFACTURER.to_owned(),
                 status.manufacturername.to_owned());
             service.properties.insert(CUSTOM_PROPERTY_MODEL.to_owned(),
@@ -85,60 +84,52 @@ impl Light {
             // is plugged in and `Off` when it is not. Availability
             // Has no effect on the API other than that you won't
             // see the light change because it lacks external power.
-            try!(manager.add_getter(Channel {
-                tags: HashSet::new(),
-                adapter: adapter_id.clone(),
-                id: self.get_available_id.clone(),
-                service: self.service_id.clone(),
-                kind: ChannelKind::Extension {
-                    vendor: Id::new("foxlink@mozilla.com"),
-                    adapter: Id::new("Philips Hue Adapter"),
-                    kind: Id::new("available"),
-                    typ: Type::OnOff,
-                },
+            try!(manager.add_channel(Channel {
+                 supports_fetch: true,
+                 kind: ChannelKind::Extension {
+                     vendor: Id::new("foxlink@mozilla.com"),
+                     adapter: Id::new("Philips Hue Adapter"),
+                     kind: Id::new("available"),
+                     typ: Type::OnOff,
+                 },
+                 ..Channel::empty(&self.get_available_id, &self.service_id, &adapter_id)
             }));
 
-            try!(manager.add_getter(Channel {
-                tags: HashSet::new(),
-                adapter: adapter_id.clone(),
-                id: self.get_power_id.clone(),
-                service: self.service_id.clone(),
+
+            try!(manager.add_channel(Channel {
+                 supports_fetch: true,
+                 kind: ChannelKind::LightOn,
+                 ..Channel::empty(&self.get_power_id, &self.service_id, &adapter_id)
+            }));
+
+            try!(manager.add_channel(Channel {
+                supports_send: true,
                 kind: ChannelKind::LightOn,
+                ..Channel::empty(&self.set_power_id, &self.service_id, &adapter_id)
             }));
 
-            try!(manager.add_setter(Channel {
-                tags: HashSet::new(),
-                adapter: adapter_id.clone(),
-                id: self.set_power_id.clone(),
-                service: self.service_id.clone(),
-                kind: ChannelKind::LightOn,
+            try!(manager.add_channel(Channel {
+                 supports_fetch: true,
+                 kind: ChannelKind::Extension {
+                     vendor: Id::new("foxlink@mozilla.com"),
+                     adapter: Id::new("Philips Hue Adapter"),
+                     kind: Id::new("Color"),
+                     typ: Type::Color,
+                 },
+                 ..Channel::empty(&self.get_color_id, &self.service_id, &adapter_id)
             }));
 
-            try!(manager.add_getter(Channel {
-                tags: HashSet::new(),
-                adapter: adapter_id.clone(),
-                id: self.get_color_id.clone(),
-                service: self.service_id.clone(),
+            try!(manager.add_channel(Channel {
+                supports_send: true,
                 kind: ChannelKind::Extension {
                     vendor: Id::new("foxlink@mozilla.com"),
                     adapter: Id::new("Philips Hue Adapter"),
                     kind: Id::new("Color"),
                     typ: Type::Color,
                 },
+                ..Channel::empty(&self.set_color_id, &self.service_id, &adapter_id)
             }));
 
-            try!(manager.add_setter(Channel {
-                tags: HashSet::new(),
-                adapter: adapter_id.clone(),
-                id: self.set_color_id.clone(),
-                service: self.service_id.clone(),
-                kind: ChannelKind::Extension {
-                    vendor: Id::new("foxlink@mozilla.com"),
-                    adapter: Id::new("Philips Hue Adapter"),
-                    kind: Id::new("Color"),
-                    typ: Type::Color,
-                },
-            }));
 
             let mut services_lock = services.lock().unwrap();
             services_lock.getters.insert(self.get_available_id.clone(), self.clone());
@@ -150,7 +141,7 @@ impl Light {
         } else if status.lighttype == "Dimmable light" {
             info!("New Philips Hue `Dimmable Light` service for light {} on bridge {}",
                 self.light_id, self.hub_id);
-            let mut service = Service::empty(self.service_id.clone(), adapter_id.clone());
+            let mut service = Service::empty(&self.service_id, &adapter_id);
             service.properties.insert(CUSTOM_PROPERTY_MANUFACTURER.to_owned(),
                 status.manufacturername.to_owned());
             service.properties.insert(CUSTOM_PROPERTY_MODEL.to_owned(),
@@ -163,33 +154,28 @@ impl Light {
 
             try!(manager.add_service(service));
 
-            try!(manager.add_getter(Channel {
-                tags: HashSet::new(),
-                adapter: adapter_id.clone(),
-                id: self.get_available_id.clone(),
-                service: self.service_id.clone(),
-                kind: ChannelKind::Extension {
-                    vendor: Id::new("foxlink@mozilla.com"),
-                    adapter: Id::new("Philips Hue Adapter"),
-                    kind: Id::new("available"),
-                    typ: Type::OnOff,
-                },
+            try!(manager.add_channel(Channel {
+                 supports_fetch: true,
+                 kind: ChannelKind::Extension {
+                     vendor: Id::new("foxlink@mozilla.com"),
+                     adapter: Id::new("Philips Hue Adapter"),
+                     kind: Id::new("available"),
+                     typ: Type::OnOff,
+                 },
+                 ..Channel::empty(&self.get_available_id, &self.service_id, &adapter_id)
             }));
 
-            try!(manager.add_getter(Channel {
-                tags: HashSet::new(),
-                adapter: adapter_id.clone(),
-                id: self.get_power_id.clone(),
-                service: self.service_id.clone(),
-                kind: ChannelKind::LightOn,
+
+            try!(manager.add_channel(Channel {
+                 supports_fetch: true,
+                 kind: ChannelKind::LightOn,
+                 ..Channel::empty(&self.get_power_id, &self.service_id, &adapter_id)
             }));
 
-            try!(manager.add_setter(Channel {
-                tags: HashSet::new(),
-                adapter: adapter_id.clone(),
-                id: self.set_power_id.clone(),
-                service: self.service_id.clone(),
-                kind: ChannelKind::LightOn,
+            try!(manager.add_channel(Channel {
+                 supports_send: true,
+                 kind: ChannelKind::LightOn,
+                 ..Channel::empty(&self.set_power_id, &self.service_id, &adapter_id)
             }));
 
             let mut services_lock = services.lock().unwrap();

--- a/src/adapters/tts/mod.rs
+++ b/src/adapters/tts/mod.rs
@@ -92,18 +92,16 @@ pub fn init(adapt: &Arc<AdapterManager>) -> Result<(), Error> {
     })));
     let service_id = service_id!("espeak@link.mozilla.org");
     let adapter_id = adapter_id!(ADAPTER_ID);
-    try!(adapt.add_service(Service::empty(service_id.clone(), adapter_id.clone())));
-    try!(adapt.add_setter(Channel {
-        tags: HashSet::new(),
-        adapter: adapter_id.clone(),
-        id: talk_setter_id.clone(),
-        service: service_id.clone(),
+    try!(adapt.add_service(Service::empty(&service_id, &adapter_id)));
+    try!(adapt.add_channel(Channel {
         kind: ChannelKind::Extension {
             vendor: Id::new(ADAPTER_VENDOR),
             adapter: Id::new(ADAPTER_NAME),
             kind: Id::new("Sentence"),
             typ: Type::String,
         },
+        supports_send: true,
+        .. Channel::empty(&talk_setter_id, &service_id, &adapter_id)
     }));
     Ok(())
 }

--- a/src/taxonomy_router.rs
+++ b/src/taxonomy_router.rs
@@ -218,8 +218,14 @@ impl Handler for TaxonomyRouter {
 
         // Selectors queries.
         get_post_api!(get_services, ServiceSelector, ["services"]);
-        get_post_api!(get_getter_channels, ChannelSelector, ["channels", "getters"]);
-        get_post_api!(get_setter_channels, ChannelSelector, ["channels", "setters"]);
+        get_post_api!(get_channels, ChannelSelector, ["channels"]);
+
+        // FIXME: Deprecate and remove
+        // FIXME: Need to tweak selector
+        get_post_api!(get_channels, ChannelSelector, ["channels", "getters"]);
+        // FIXME: Deprecate and remove
+        // FIXME: Need to tweak selector
+        get_post_api!(get_channels, ChannelSelector, ["channels", "setters"]);
 
         // Fetching and getting values.
         // We can't use a GET http method here because the Fetch() DOM api
@@ -232,11 +238,21 @@ impl Handler for TaxonomyRouter {
                       services => Vec<ServiceSelector>,
                       tags => Vec<Id<TagId>>,
                       ["services", "tags"], Method::Post);
-        payload_api2!(add_getter_tags,
+        payload_api2!(add_channel_tags,
+                    channels => Vec<ChannelSelector>,
+                    tags => Vec<Id<TagId>>,
+                    ["channels", "tags"], Method::Post);
+
+
+      // FIXME: Deprecate and remove
+      // FIXME: Need to tweak selector
+        payload_api2!(add_channel_tags,
                       getters => Vec<ChannelSelector>,
                       tags => Vec<Id<TagId>>,
                       ["channels", "getters", "tags"], Method::Post);
-        payload_api2!(add_setter_tags,
+      // FIXME: Deprecate and remove
+      // FIXME: Need to tweak selector
+        payload_api2!(add_channel_tags,
                       setters => Vec<ChannelSelector>,
                       tags => Vec<Id<TagId>>,
                       ["channels", "setters", "tags"], Method::Post);
@@ -246,11 +262,21 @@ impl Handler for TaxonomyRouter {
                       services => Vec<ServiceSelector>,
                       tags => Vec<Id<TagId>>,
                       ["services", "tags"], Method::Delete);
-        payload_api2!(remove_getter_tags,
+        payload_api2!(remove_channel_tags,
+                       channels => Vec<ChannelSelector>,
+                       tags => Vec<Id<TagId>>,
+                       ["channels", "tags"], Method::Delete);
+
+          // FIXME: Deprecate and remove
+          // FIXME: Need to tweak selector
+        payload_api2!(remove_channel_tags,
                       getters => Vec<ChannelSelector>,
                       tags => Vec<Id<TagId>>,
                       ["channels", "getters", "tags"], Method::Delete);
-        payload_api2!(remove_setter_tags,
+
+          // FIXME: Deprecate and remove
+          // FIXME: Need to tweak selector
+        payload_api2!(remove_channel_tags,
                       setters => Vec<ChannelSelector>,
                       tags => Vec<Id<TagId>>,
                       ["channels", "setters", "tags"], Method::Delete);
@@ -313,7 +339,7 @@ describe! taxonomy_router {
                                     Headers::new(),
                                     &mount).unwrap();
         let body = response::extract_body_to_string(response);
-        let s = r#"[{"adapter":"clock@link.mozilla.org","getters":{"getter:interval.clock@link.mozilla.org":{"adapter":"clock@link.mozilla.org","id":"getter:interval.clock@link.mozilla.org","kind":"CountEveryInterval","service":"service:clock@link.mozilla.org","tags":[]},"getter:timeofday.clock@link.mozilla.org":{"adapter":"clock@link.mozilla.org","id":"getter:timeofday.clock@link.mozilla.org","kind":"CurrentTimeOfDay","service":"service:clock@link.mozilla.org","tags":[]},"getter:timestamp.clock@link.mozilla.org":{"adapter":"clock@link.mozilla.org","id":"getter:timestamp.clock@link.mozilla.org","kind":"CurrentTime","service":"service:clock@link.mozilla.org","tags":[]}},"id":"service:clock@link.mozilla.org","properties":{"model":"Mozilla clock v1"},"setters":{},"tags":[]}]"#;
+        let s = r#"[{"adapter":"clock@link.mozilla.org","channels":{"getter:interval.clock@link.mozilla.org":{"adapter":"clock@link.mozilla.org","id":"getter:interval.clock@link.mozilla.org","kind":"CountEveryInterval","service":"service:clock@link.mozilla.org","supports_fetch":false,"supports_send":false,"tags":[]},"getter:timeofday.clock@link.mozilla.org":{"adapter":"clock@link.mozilla.org","id":"getter:timeofday.clock@link.mozilla.org","kind":"CurrentTimeOfDay","service":"service:clock@link.mozilla.org","supports_fetch":true,"supports_send":false,"tags":[]},"getter:timestamp.clock@link.mozilla.org":{"adapter":"clock@link.mozilla.org","id":"getter:timestamp.clock@link.mozilla.org","kind":"CurrentTime","service":"service:clock@link.mozilla.org","supports_fetch":true,"supports_send":false,"tags":[]}},"id":"service:clock@link.mozilla.org","properties":{"model":"Mozilla clock v1"},"tags":[]}]"#;
 
         assert_eq!(body, s);
     }
@@ -324,7 +350,7 @@ describe! taxonomy_router {
                                     r#"[{"id":"service:clock@link.mozilla.org"}]"#,
                                     &mount).unwrap();
         let body = response::extract_body_to_string(response);
-        let s = r#"[{"adapter":"clock@link.mozilla.org","getters":{"getter:interval.clock@link.mozilla.org":{"adapter":"clock@link.mozilla.org","id":"getter:interval.clock@link.mozilla.org","kind":"CountEveryInterval","service":"service:clock@link.mozilla.org","tags":[]},"getter:timeofday.clock@link.mozilla.org":{"adapter":"clock@link.mozilla.org","id":"getter:timeofday.clock@link.mozilla.org","kind":"CurrentTimeOfDay","service":"service:clock@link.mozilla.org","tags":[]},"getter:timestamp.clock@link.mozilla.org":{"adapter":"clock@link.mozilla.org","id":"getter:timestamp.clock@link.mozilla.org","kind":"CurrentTime","service":"service:clock@link.mozilla.org","tags":[]}},"id":"service:clock@link.mozilla.org","properties":{"model":"Mozilla clock v1"},"setters":{},"tags":[]}]"#;
+        let s = r#"[{"adapter":"clock@link.mozilla.org","channels":{"getter:interval.clock@link.mozilla.org":{"adapter":"clock@link.mozilla.org","id":"getter:interval.clock@link.mozilla.org","kind":"CountEveryInterval","service":"service:clock@link.mozilla.org","supports_fetch":false,"supports_send":false,"tags":[]},"getter:timeofday.clock@link.mozilla.org":{"adapter":"clock@link.mozilla.org","id":"getter:timeofday.clock@link.mozilla.org","kind":"CurrentTimeOfDay","service":"service:clock@link.mozilla.org","supports_fetch":true,"supports_send":false,"tags":[]},"getter:timestamp.clock@link.mozilla.org":{"adapter":"clock@link.mozilla.org","id":"getter:timestamp.clock@link.mozilla.org","kind":"CurrentTime","service":"service:clock@link.mozilla.org","supports_fetch":true,"supports_send":false,"tags":[]}},"id":"service:clock@link.mozilla.org","properties":{"model":"Mozilla clock v1"},"tags":[]}]"#;
 
         assert_eq!(body, s);
     }
@@ -344,7 +370,7 @@ describe! binary_getter {
         use iron::headers::{ Authorization, Bearer, ContentLength, ContentType };
         use iron_test::{ request, response };
         use mount::Mount;
-        use std::collections::{ HashMap, HashSet };
+        use std::collections::HashMap;
         use std::sync::Arc;
         use stubs::controller::ControllerStub;
         use transformable_channels::mpsc::*;
@@ -413,18 +439,16 @@ describe! binary_getter {
                 try!(adapt.add_adapter(Arc::new(BinaryAdapter { })));
                 let service_id = service_id!("service@test");
                 let adapter_id = adapter_id!("adapter@test");
-                try!(adapt.add_service(Service::empty(service_id.clone(), adapter_id.clone())));
-                try!(adapt.add_getter(Channel {
-                    tags: HashSet::new(),
-                    adapter: adapter_id.clone(),
-                    id: Id::new("getter:binary@link.mozilla.org"),
-                    service: service_id.clone(),
+                try!(adapt.add_service(Service::empty(&service_id, &adapter_id)));
+                try!(adapt.add_channel(Channel {
+                    supports_fetch: true,
                     kind: ChannelKind::Extension {
                         vendor: Id::new(ADAPTER_VENDOR),
                         adapter: Id::new(ADAPTER_NAME),
                         kind: Id::new("binary_getter"),
                         typ: Type::Binary,
                     },
+                    ..Channel::empty(&Id::new("getter:binary@link.mozilla.org"), &service_id, &adapter_id)
                 }));
 
                 Ok(())


### PR DESCRIPTION
This set of patches continues towards Decentralized Taxonomy:
- A channel watch will now be informed upon topology changes, regardless of whether these changes occur in getter or setter channels;
- Getter and setter channels are now fully merged. Instead of several different data types, we now have a single structure `Channel`, with capabilities `supports_send`, `supports_fetch`, `supports_watch`.

Note that this set of patches is built on top of the (yet unlanded) https://github.com/fxbox/foxbox/pull/478.
