### PR TITLE
Decentralizing: Making it possible for adapters to manipulate Payload instead of Value

### DIFF
--- a/components/openzwave-adapter/src/watchers.rs
+++ b/components/openzwave-adapter/src/watchers.rs
@@ -8,7 +8,7 @@ use transformable_channels::mpsc::ExtSender;
 use std::collections::HashMap;
 use std::sync::{ Arc, Mutex, Weak };
 
-pub type SyncSender = Mutex<Box<ExtSender<WatchEvent>>>;
+pub type SyncSender = Mutex<Box<ExtSender<WatchEvent<Value>>>>;
 type WatchersMap = HashMap<usize, Arc<SyncSender>>;
 type RangedWeakSender = (Option<Box<Range>>, Weak<SyncSender>);
 pub type RangedSyncSender = (Option<Box<Range>>, Arc<SyncSender>);

--- a/components/taxonomy/src/adapter_utils.rs
+++ b/components/taxonomy/src/adapter_utils.rs
@@ -1,6 +1,7 @@
 //! Utilities for writing adapters.
 
-use api::{ Error, User };
+use api::{ Error, InternalError, User };
+use io::*;
 use manager::*;
 use services::Channel;
 use util::{ Id, AdapterId };
@@ -8,6 +9,8 @@ use values::*;
 
 use std::collections::HashMap;
 use std::sync::{ Arc, Mutex };
+
+use transformable_channels::mpsc::*;
 
 /// A simple way of converting an Adapter to an Adapter + Sync.
 ///
@@ -58,5 +61,103 @@ impl<T> Adapter for MakeSyncAdapter<T> where T: Adapter {
 
     fn register_watch(&self, watch: Vec<WatchTarget>) -> WatchResult {
         self.lock.lock().unwrap().register_watch(watch)
+    }
+}
+
+
+pub struct RawAdapterForAdapter {
+    adapter: Arc<Adapter>
+}
+impl RawAdapterForAdapter {
+    pub fn new(adapter: Arc<Adapter>) -> Self {
+        RawAdapterForAdapter {
+            adapter: adapter
+        }
+    }
+}
+
+impl RawAdapter for RawAdapterForAdapter {
+    fn id(&self) -> Id<AdapterId> {
+        self.adapter.id()
+    }
+    fn stop(&self) {
+        self.adapter.stop()
+    }
+    fn fetch_values(&self, mut target: Vec<(Id<Channel>, Type)>, user: User) -> ResultMap<Id<Channel>, Option<(Payload, Type)>, Error> {
+        let types : HashMap<_, _> = target.iter().cloned().collect();
+        let channels : Vec<_> = target.drain(..).map(|(id, _)| id).collect();
+        let values = self.adapter.fetch_values(channels, user);
+        values.iter().map(|(id, result)| {
+            let result = match *result {
+                Err(ref err) => Err(err.clone()),
+                Ok(None) => Ok(None),
+                Ok(Some(ref value)) => {
+                    match types.get(&id) {
+                        None => Err(Error::InternalError(InternalError::WrongChannel(id.clone()))),
+                        Some(type_) => Payload::from_value(&value, type_)
+                            .map(|payload| Some((payload, type_.clone())))
+                    }
+                },
+            };
+            (id.clone(), result)
+        }).collect()
+    }
+
+    fn send_values(&self, mut values: HashMap<Id<Channel>, (Payload, Type)>, user: User) -> ResultMap<Id<Channel>, (), Error> {
+        let mut send = HashMap::new();
+        let mut failures = HashMap::new();
+        for (id, (payload, type_)) in values.drain() {
+            match payload.to_value(&type_) {
+                Err(err) => {
+                    failures.insert(id, Err(err));
+                },
+                Ok(value) => {
+                    send.insert(id, value);
+                },
+            }
+        }
+        let mut results = self.adapter.send_values(send, user);
+        results.extend(failures);
+        results
+    }
+
+    fn register_watch(&self, mut targets: Vec<RawWatchTarget>) -> WatchResult {
+        let mut send : Vec<(_, _, Box<ExtSender<WatchEvent<Value>>>)> = Vec::new();
+        let mut failures = Vec::new();
+        for (id, filter, event_type, sender) in targets.drain(..) { // FIXME: Do I really need event_type? Why? Shouldn't it be part of ChannelKind?
+            let sender = Box::new(sender.map(move |event| {
+                match event {
+                    WatchEvent::Enter { id, value } => {
+                        match Payload::from_value(&value, &event_type) {
+                            Ok(payload) =>
+                                WatchEvent::Enter { id: id, value: (payload, event_type.clone()) },
+                            Err(err) =>
+                                WatchEvent::Error { id: id, error: err }
+                        }
+                    }
+                    WatchEvent::Exit { id, value } => {
+                        match Payload::from_value(&value, &event_type) {
+                            Ok(payload) =>
+                                WatchEvent::Exit { id: id, value: (payload, event_type.clone()) },
+                            Err(err) =>
+                                WatchEvent::Error { id: id, error: err }
+                        }
+                    }
+                    WatchEvent::Error { id, error } =>
+                        WatchEvent::Error { id: id, error: error }
+                }
+            }));
+            if let Some((payload, type_)) = filter {
+                match payload.to_value(&type_) {
+                    Err(err) => { failures.push((id, Err(err))); },
+                    Ok(value) => { send.push((id, Some(value), sender)); },
+                }
+            } else {
+                send.push((id, None, sender));
+            }
+        }
+        let mut result = self.adapter.register_watch(send);
+        result.extend(failures);
+        result
     }
 }

--- a/components/taxonomy/src/api.rs
+++ b/components/taxonomy/src/api.rs
@@ -593,6 +593,7 @@ pub trait API: Send {
     /// # extern crate foxbox_taxonomy;
     /// # use foxbox_taxonomy::selector::*;
     /// # use foxbox_taxonomy::api::*;
+    /// # use foxbox_taxonomy::io::*;
     /// # use foxbox_taxonomy::values::*;
     ///
     /// # fn main() {
@@ -604,7 +605,7 @@ pub trait API: Send {
     ///   "value": {"OnOff": "On"}
     /// }"#;
     ///
-    /// # TargetMap::<ChannelSelector, Value>::from_str(&source).unwrap();
+    /// # TargetMap::<ChannelSelector, Payload>::from_str(&source).unwrap();
     ///
     /// // The following argument will send `On` to two setters and `Unit` to everything
     /// // that supports `Ready`.
@@ -617,7 +618,7 @@ pub trait API: Send {
     ///   "value": {"Unit": null}
     /// }]"#;
     ///
-    /// # TargetMap::<ChannelSelector, Value>::from_str(&source).unwrap();
+    /// # TargetMap::<ChannelSelector, Payload>::from_str(&source).unwrap();
     ///
     /// # }
     /// ```

--- a/components/taxonomy/src/api.rs
+++ b/components/taxonomy/src/api.rs
@@ -13,10 +13,11 @@
 //!
 //!
 
+use io::*;
 use services::*;
 use selector::*;
 pub use util::{ ResultMap, TargetMap, Targetted };
-use values::{ Value, TypeError };
+use values::{ Value, Type, TypeError };
 
 use transformable_channels::mpsc::*;
 
@@ -26,15 +27,30 @@ use std::error::Error as std_error;
 use serde::ser::Serialize;
 use serde_json::value::Serializer;
 
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub enum Operation {
+    Fetch,
+    Send,
+    Watch
+}
+impl fmt::Display for Operation {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        use self::Operation::*;
+        match *self {
+            Fetch => f.write_str("Fetch"),
+            Send => f.write_str("Send"),
+            Watch => f.write_str("Watch"),
+        }
+    }
+}
+
+
 /// An error that arose during interaction with either a device, an adapter or the
 /// adapter manager
-#[derive(Deserialize, Serialize, Debug, Clone)]
+#[derive(Clone, Debug, Deserialize, Serialize)]
 pub enum Error {
-    /// Attempting to fetch a value from a Channel that doesn't support this operation.
-    GetterDoesNotSupportPolling(Id<Channel>),
-
-    /// Attempting to watch a value from a Channel that doesn't support this operation.
-    GetterDoesNotSupportWatching(Id<Channel>),
+    /// Attempting to execute a value from a Channel that doesn't support this operation.
+    OperationNotSupported(Operation, Id<Channel>),
 
     /// Attempting to watch all values from a Channel that requires a filter.
     /// For instance, some Channel may be updated 60 times per second. Attempting to
@@ -51,6 +67,9 @@ pub enum Error {
     /// An error internal to the foxbox or an adapter. Normally, these errors should never
     /// arise from the high-level API.
     InternalError(InternalError),
+
+    // An error happened while attempting to parse a value.
+    ParseError(ParseError),
 }
 
 impl ToJSON for Error {
@@ -69,12 +88,12 @@ impl ToJSON for Error {
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
-            Error::GetterDoesNotSupportPolling(ref getter) |
-            Error::GetterDoesNotSupportWatching(ref getter) |
+            Error::OperationNotSupported(ref operation, ref channel) => write!(f, "{}: {} {}", self.description(), operation, channel),
             Error::GetterRequiresThresholdForWatching(ref getter) => write!(f, "{}: {}", self.description(), getter),
             Error::TypeError(ref err) => write!(f, "{}: {}", self.description(), err),
             Error::InvalidValue(ref value) => write!(f, "{}: {:?}",self.description(), value),
             Error::InternalError(ref err) => write!(f, "{}: {:?}", self.description(), err), // TODO implement Display for InternalError as well
+            Error::ParseError(ref err) => write!(f, "{}: {:?}", self.description(), err), // TODO implement Display for ParseError as well
         }
     }
 }
@@ -82,12 +101,12 @@ impl fmt::Display for Error {
 impl error::Error for Error {
     fn description(&self) -> &str {
         match *self {
-            Error::GetterDoesNotSupportPolling(_) => "Attempting to fetch a value from a Channel that doesn't support this operation",
-            Error::GetterDoesNotSupportWatching(_) => "Attempting to watch a value from a Channel that doesn't support this operation",
+            Error::OperationNotSupported(_, _) => "Attempting to perform a call to a Channel that does not support such calls",
             Error::GetterRequiresThresholdForWatching(_) => "Attempting to watch all value from a Channel that requires a filter",
             Error::TypeError(_) => "Attempting to send a value with a wrong type",
             Error::InvalidValue(_) => "Attempting to send an invalid value",
-            Error::InternalError(_) => "Internal Error" // TODO implement Error for InternalError as well
+            Error::InternalError(_) => "Internal Error", // TODO implement Error for InternalError as well
+            Error::ParseError(ref err) => err.description()
         }
     }
 
@@ -115,6 +134,8 @@ pub enum InternalError {
     /// Attempting to register an adapter with an id that is already used.
     DuplicateAdapter(Id<AdapterId>),
 
+    WrongChannel(Id<Channel>),
+
     /// Attempting to register a channel with an adapter that doesn't match that of its service.
     ConflictingAdapter(Id<AdapterId>, Id<AdapterId>),
 
@@ -135,20 +156,24 @@ pub enum WatchEvent {
     /// is available. Otherwise, never fired.
     EnterRange {
         /// The channel that sent the value.
-        from: Id<Channel>,
+        channel: Id<Channel>,
 
         /// The actual value.
-        value: Value
+        value: Payload,
+
+        type_: Type,
     },
 
     /// If a range was specified when we registered for watching, `ExitRange` is fired whenever
     /// we exit this range. Otherwise, never fired.
     ExitRange {
         /// The channel that sent the value.
-        from: Id<Channel>,
+        channel: Id<Channel>,
 
         /// The actual value.
-        value: Value
+        value: Payload,
+
+        type_: Type,
     },
 
     /// The set of devices being watched has changed, typically either
@@ -161,10 +186,7 @@ pub enum WatchEvent {
     /// added. Payload is the id of the device that was added.
     ChannelAdded(Id<Channel>),
 
-    /// One of the channels encountered an error during initialization.
-    /// This channel will not be watched, but other channels will remain
-    /// watched.
-    InitializationError {
+    Error {
         channel: Id<Channel>,
         error: Error
     },
@@ -184,28 +206,26 @@ fn test_user_partialeq() {
     assert_eq!(User::Id(1), User::Id(1));
 }
 
-impl<K> Parser<Targetted<K, Value>> for Targetted<K, Value> where K: Parser<K> + Clone {
+impl<K> Parser<Targetted<K, Payload>> for Targetted<K, Payload> where K: Parser<K> + Clone {
     fn description() -> String {
         format!("Targetted<{}, Value>", K::description())
     }
-    fn parse(path: Path, source: &mut JSON) -> Result<Self, ParseError> {
+    fn parse(path: Path, source: &JSON) -> Result<Self, ParseError> {
         if source.is_object() {
             // Default format: an object {select, value}.
             let select = try!(path.push("select", |path| Vec::<K>::take(path, source, "select")));
-            let payload = try!(path.push("value", |path| Value::take(path, source, "value")));
+            let payload = try!(path.push("value", |path| Payload::take(path, source, "value")));
             Ok(Targetted {
                 select: select,
                 payload: payload
             })
-        } else if let JSON::Array(ref mut array) = *source {
+        } else if let JSON::Array(ref array) = *source {
             // Fallback format: an array of two values.
             if array.len() != 2 {
                 return Err(ParseError::type_error(&Self::description() as &str, &path, "an array of length 2"))
             }
-            let mut right = array.pop().unwrap(); // We just checked that length == 2
-            let mut left = array.pop().unwrap(); // We just checked that length == 2
-            let select = try!(path.push_index(0, |path| Vec::<K>::parse(path, &mut left)));
-            let payload = try!(path.push_index(1, |path| Value::parse(path, &mut right)));
+            let select = try!(path.push_index(0, |path| Vec::<K>::parse(path, &array[0])));
+            let payload = try!(path.push_index(1, |path| Payload::parse(path, &array[1])));
             Ok(Targetted {
                 select: select,
                 payload: payload
@@ -216,11 +236,11 @@ impl<K> Parser<Targetted<K, Value>> for Targetted<K, Value> where K: Parser<K> +
     }
 }
 
-impl<K> Parser<Targetted<K, Exactly<Value>>> for Targetted<K, Exactly<Value>> where K: Parser<K> + Clone {
+impl<K> Parser<Targetted<K, Exactly<(Payload, Type)>>> for Targetted<K, Exactly<(Payload, Type)>> where K: Parser<K> + Clone {
     fn description() -> String {
-        format!("Targetted<{}, Value>", K::description())
+        format!("Targetted<{}, range>", K::description())
     }
-    fn parse(path: Path, source: &mut JSON) -> Result<Self, ParseError> {
+    fn parse(path: Path, source: &JSON) -> Result<Self, ParseError> {
         let select = try!(path.push("select", |path| Vec::<K>::take(path, source, "select")));
         if let Some(&JSON::String(ref str)) = source.find("range") {
             if &str as &str == "Never" {
@@ -230,13 +250,15 @@ impl<K> Parser<Targetted<K, Exactly<Value>>> for Targetted<K, Exactly<Value>> wh
                 })
             }
         }
-        let payload = match path.push("range", |path| Exactly::<Value>::take_opt(path, source, "range")) {
-            Some(result) => try!(result),
-            None => Exactly::Always
+        let result = match path.push("range", |path| Exactly::<Payload>::take_opt(path, source, "range")) {
+            Some(Ok(Exactly::Exactly(payload))) => Exactly::Exactly((payload, Type::Range)),
+            Some(Ok(Exactly::Always)) | None => Exactly::Always,
+            Some(Ok(Exactly::Never)) => Exactly::Never,
+            Some(Err(err)) => return Err(err),
         };
         Ok(Targetted {
             select: select,
-            payload: payload
+            payload: result
         })
     }
 }
@@ -548,7 +570,7 @@ pub trait API: Send {
     /// ## Success
     ///
     /// The results, per getter.
-    fn fetch_values(&self, Vec<ChannelSelector>, user: User) -> ResultMap<Id<Channel>, Option<Value>, Error>;
+    fn fetch_values(&self, Vec<ChannelSelector>, user: User) -> ResultMap<Id<Channel>, Option<(Payload, Type)>, Error>;
 
     /// Send a bunch of values to a set of channels.
     ///
@@ -608,7 +630,7 @@ pub trait API: Send {
     /// ## Success
     ///
     /// The results, per setter.
-    fn send_values(&self, TargetMap<ChannelSelector, Value>, user: User) -> ResultMap<Id<Channel>, (), Error>;
+    fn send_values(&self, TargetMap<ChannelSelector, Payload>, user: User) -> ResultMap<Id<Channel>, (), Error>;
 
     /// Watch for changes from channels.
     ///
@@ -634,7 +656,7 @@ pub trait API: Send {
     /// # `WebSocket` API
     ///
     /// `/api/v1/channels/watch`
-    fn watch_values(& self, watch: TargetMap<ChannelSelector, Exactly<Value>>,
+    fn watch_values(& self, watch: TargetMap<ChannelSelector, Exactly<(Payload, Type)>>,
             on_event: Box<ExtSender<WatchEvent>>) -> Self::WatchGuard;
 
     /// A value that causes a disconnection once it is dropped.

--- a/components/taxonomy/src/backend.rs
+++ b/components/taxonomy/src/backend.rs
@@ -1,9 +1,11 @@
 //! An API for plugging in adapters.
 
-use adapter::{ Adapter, AdapterWatchGuard, ResultMap, WatchEvent as AdapterWatchEvent };
+use adapter::{ Adapter, AdapterWatchGuard, RawAdapter,  WatchEvent as AdapterWatchEvent };
+use adapter_utils::RawAdapterForAdapter;
 use transact::InsertInMap;
 
 use api::{ Error, InternalError, TargetMap, Targetted, WatchEvent };
+use io::*;
 use selector::*;
 use services::*;
 use tag_storage::TagStorage;
@@ -36,16 +38,16 @@ macro_rules! log_debug_assert {
 /// Whenever possible, the `AdapterManager` attempts to place calls to the Adapters
 /// after it has released its locks. An `AdapterRequest` represents stuff that has
 /// been extracted from the maps while they were locked for use after unlocking.
-pub type AdapterRequest<T> = HashMap<Id<AdapterId>, (Arc<Adapter>, T)>;
+pub type AdapterRequest<T> = HashMap<Id<AdapterId>, (Arc<RawAdapter>, T)>;
 
 /// A request to an adapter, for performing a `fetch` operation.
 pub type FetchRequest = AdapterRequest<HashMap<Id<Channel>, Type>>;
 
 /// A request to an adapter, for performing a `send` operation.
-pub type SendRequest = AdapterRequest<(HashMap<Id<Channel>, Value>, ResultMap<Id<Channel>, (), Error>)>;
+pub type SendRequest = AdapterRequest<HashMap<Id<Channel>, (Payload, Type)>>;
 
 /// A request to an adapter, for performing a `watch` operation.
-pub type WatchRequest = AdapterRequest<Vec<(Id<Channel>, Option<Value>, Weak<WatcherData>)>>;
+pub type WatchRequest = AdapterRequest<Vec<(Id<Channel>, Option<(Payload, Type)>, /*values*/Type, Weak<WatcherData>)>>;
 
 pub type WatchGuardCommit = Vec<(Weak<WatcherData>, Vec<(Id<Channel>, Box<AdapterWatchGuard>)>)>;
 
@@ -129,14 +131,14 @@ impl<'a> ServiceLike for ServiceView<'a> {
 /// Data and metadata on an adapter.
 struct AdapterData {
     /// The implementation of the adapter.
-    adapter: Arc<Adapter>,
+    adapter: Arc<RawAdapter>,
 
     /// The services for this adapter.
     services: HashMap<Id<ServiceId>, Arc<SubCell<ServiceData>>>,
 }
 
 impl AdapterData {
-    fn new(adapter: Arc<Adapter>) -> Self {
+    fn new(adapter: Arc<RawAdapter>) -> Self {
         AdapterData {
             adapter: adapter,
             services: HashMap::new(),
@@ -144,7 +146,7 @@ impl AdapterData {
     }
 }
 impl Deref for AdapterData {
-    type Target = Arc<Adapter>;
+    type Target = Arc<RawAdapter>;
     fn deref(&self) -> &Self::Target {
         &self.adapter
     }
@@ -180,9 +182,9 @@ impl Tagged for Channel {
 #[derive(Copy, Clone, Debug, Eq, Hash, PartialEq)]
 pub struct WatchKey(usize);
 
-/// Data and metadata on a getter.
+/// Data and metadata on a channel.
 struct ChannelData {
-    /// The getter itself.
+    /// The channel itself.
     channel: Channel,
 
     /// The tags of the service.
@@ -230,7 +232,7 @@ impl Tagged for ChannelData {
 /// yet. The `WatcherData` is materialized as a `WatchGuard` in userland.
 pub struct WatcherData {
     /// The criteria for watching.
-    watch: TargetMap<ChannelSelector, Exactly<Value>>,
+    watch: TargetMap<ChannelSelector, Exactly<(Payload, Type)>>,
 
     /// The listener for this watch.
     on_event: Mutex<Box<ExtSender<WatchEvent>>>,
@@ -261,7 +263,7 @@ impl PartialEq for WatcherData {
 }
 
 impl WatcherData {
-    fn new(liveness: &Arc<Liveness>, key: WatchKey, watch:TargetMap<ChannelSelector, Exactly<Value>>, on_event: Box<ExtSender<WatchEvent>>) -> Self {
+    fn new(liveness: &Arc<Liveness>, key: WatchKey, watch:TargetMap<ChannelSelector, Exactly<(Payload, Type)>>, on_event: Box<ExtSender<WatchEvent>>) -> Self {
         WatcherData {
             key: key,
             on_event: Mutex::new(on_event),
@@ -298,7 +300,7 @@ impl WatchMap {
             liveness: liveness.clone()
         }
     }
-    fn create(&mut self, watch:TargetMap<ChannelSelector, Exactly<Value>>, on_event: Box<ExtSender<WatchEvent>>) -> Arc<WatcherData> {
+    fn create(&mut self, watch:TargetMap<ChannelSelector, Exactly<(Payload, Type)>>, on_event: Box<ExtSender<WatchEvent>>) -> Arc<WatcherData> {
         let id = WatchKey(self.counter);
         self.counter += 1;
         let watcher = Arc::new(WatcherData::new(&self.liveness, id, watch, on_event));
@@ -558,6 +560,9 @@ impl State {
     ///
     /// Returns an error if an adapter with the same id is already present.
     pub fn add_adapter(&mut self, adapter: Arc<Adapter>) -> Result<(), Error> {
+        self.add_raw_adapter(Arc::new(RawAdapterForAdapter::new(adapter)))
+    }
+    pub fn add_raw_adapter(&mut self, adapter: Arc<RawAdapter>) -> Result<(), Error> {
         match self.adapter_by_id.entry(adapter.id()) {
             Entry::Occupied(_) => return Err(Error::InternalError(InternalError::DuplicateAdapter(adapter.id()))),
             Entry::Vacant(entry) => {
@@ -890,40 +895,21 @@ impl State {
 
 
     /// Send values to a set of channels
-    pub fn prepare_send_values(&self, mut keyvalues: TargetMap<ChannelSelector, Value>) -> SendRequest {
+    pub fn prepare_send_values(&self, mut keyvalues: TargetMap<ChannelSelector, Payload>) -> SendRequest {
         // First determine the channels and group them by adapter.
         let mut per_adapter = HashMap::new();
-        for Targetted {select: selectors, payload: value} in keyvalues.drain(..) {
+        for Targetted { select: selectors, payload } in keyvalues.drain(..) {
             Self::with_channels(selectors, &self.channel_by_id, |data| {
                 use std::collections::hash_map::Entry::*;
                 if !data.supports_send {
                     return;
                 }
                 let id = data.channel.id.clone();
-
-                // Check that the values we are about to send have the correct type. If they
-                // don't, no need to even send them to the Adapter.
-                let typ = data.channel.kind.get_type();
-                let checked = if value.get_type() == typ {
-                    Ok(value.clone())
-                } else {
-                    Err(Error::TypeError(TypeError {
-                        got: value.get_type(),
-                        expected: typ
-                    }))
-                };
+                let value = (payload.clone(), data.kind.get_type());
                 match per_adapter.entry(data.channel.adapter.clone()) {
                     Vacant(entry) => {
                         let mut request = HashMap::new();
-                        let mut failures = HashMap::new();
-                        match checked {
-                            Ok(value) => {
-                                request.insert(id, value);
-                            }
-                            Err(error) => {
-                                failures.insert(id, Err(error));
-                            }
-                        }
+                        request.insert(id, value.clone());
                         let adapter = match self.adapter_by_id.get(&data.channel.adapter) {
                             None => {
                                 log_debug_assert!(false, "Internal inconsistency: could not find adapter {}", data.channel.adapter);
@@ -931,18 +917,11 @@ impl State {
                             }
                             Some(adapter) => adapter
                         };
-                        entry.insert((adapter.adapter.clone(), (request, failures)));
+                        entry.insert((adapter.adapter.clone(), request));
                     }
                     Occupied(mut entry) => {
-                        let &mut(_, (ref mut request, ref mut failures)) = entry.get_mut();
-                        match checked {
-                            Ok(value) => {
-                                request.insert(id, value);
-                            }
-                            Err(error) => {
-                                failures.insert(id, Err(error));
-                            }
-                        }
+                        let &mut(_, ref mut request) = entry.get_mut();
+                        request.insert(id, value.clone());
                     }
                 }
             })
@@ -952,7 +931,7 @@ impl State {
 
     fn aux_start_channel_watch(watcher: &mut Arc<WatcherData>,
         getter_data: &mut ChannelData,
-        filter: &Exactly<Value>,
+        filter: &Exactly<(Payload, Type)>,
         adapter_by_id: &HashMap<Id<AdapterId>, AdapterData>,
         per_adapter: &mut WatchRequest)
     {
@@ -960,6 +939,8 @@ impl State {
 
         let id = getter_data.id.clone();
         let adapter = getter_data.adapter.clone();
+
+        let type_ = getter_data.kind.get_type();
 
         let insert_in_getter =
             match InsertInMap::start(&mut getter_data.watchers, vec![ ( watcher.key, Arc::downgrade(watcher) )] ) {
@@ -991,17 +972,17 @@ impl State {
                         adapter_data.adapter.clone()
                     }
                 };
-                entry.insert((adapter, (vec![(id, range, Arc::downgrade(watcher) )])));
+                entry.insert((adapter, (vec![(id, range, type_, Arc::downgrade(watcher) )])));
             },
             Occupied(mut entry) => {
-                (entry.get_mut().1).push((id, range, Arc::downgrade(watcher)));
+                (entry.get_mut().1).push((id, range, type_, Arc::downgrade(watcher)));
             }
         }
 
         insert_in_getter.commit();
     }
 
-    pub fn prepare_channel_watch(&mut self, mut watch: TargetMap<ChannelSelector, Exactly<Value>>,
+    pub fn prepare_channel_watch(&mut self, mut watch: TargetMap<ChannelSelector, Exactly<(Payload, Type)>>,
         on_event: Box<ExtSender<WatchEvent>>) -> (WatchRequest, WatchKey, Arc<AtomicBool>)
     {
         // Prepare the watcher and store it. Once we leave the lock, every time a channel is
@@ -1090,7 +1071,7 @@ impl State {
 
         let mut to_add = vec![];
         for (_, (adapter, mut adapter_request)) in per_adapter.drain() {
-            for (id, range, weak_watch_data) in adapter_request.drain(..) {
+            for (id, range, event_type, weak_watch_data) in adapter_request.drain(..) {
                 let watch_data = match weak_watch_data.upgrade() {
                     None => {
                         // The watch_data has already been dropped, nothing to do.
@@ -1116,26 +1097,33 @@ impl State {
                         return None;
                     }
                     Some(match event {
-                        AdapterWatchEvent::Enter { id, value } =>
+                        AdapterWatchEvent::Enter { id, value: (payload, type_) } =>
                             WatchEvent::EnterRange {
-                                from: id,
-                                value: value
+                                channel: id,
+                                value: payload,
+                                type_: type_
                             },
-                        AdapterWatchEvent::Exit { id, value } =>
+                        AdapterWatchEvent::Exit { id, value: (payload, type_) } =>
                             WatchEvent::ExitRange {
-                                from: id,
-                                value: value
+                                channel: id,
+                                value: payload,
+                                type_: type_
                             },
+                        AdapterWatchEvent::Error { id, error } =>
+                            WatchEvent::Error {
+                                channel: id,
+                                error: error
+                            }
                     })
                 });
 
                 let mut guards = vec![];
-                for (id, result) in adapter.register_watch(vec![(id, range, Box::new(on_ok))]) {
+                for (id, result) in adapter.register_watch(vec![(id, range, event_type, Box::new(on_ok))]) {
                     debug!(target: "Taxonomy-backend", "State::start_watch, registered watch for {} => {}.", id, result.is_ok());
 
                     match result {
                         Err(err) => {
-                            let event = WatchEvent::InitializationError {
+                            let event = WatchEvent::Error {
                                 channel: id.clone(),
                                 error: err
                             };

--- a/components/taxonomy/src/fake_adapter.rs
+++ b/components/taxonomy/src/fake_adapter.rs
@@ -49,7 +49,7 @@ type SyncMap<K, V> = Arc<Mutex<HashMap<K, V>>>;
 
 struct WatcherState {
     filter: Option<Box<Range>>,
-    on_event: Box<ExtSender<WatchEvent>>,
+    on_event: Box<ExtSender<WatchEvent<Value>>>,
     is_met: RefCell<bool>, /* is_met*/
     is_dropped: Arc<AtomicBool>, /* is_dropped */
 }

--- a/components/taxonomy/src/io.rs
+++ b/components/taxonomy/src/io.rs
@@ -1,0 +1,66 @@
+//! Representation of data.
+//!
+//! Instances of `Payload` are typically combinations of JSON and binary components.
+use api::Error;
+use parse::*;
+use values::*;
+
+#[derive(Clone, Serialize, Deserialize, Debug, PartialEq)]
+pub struct Payload {
+    json: JSON
+}
+
+impl Payload {
+    /// Serialize a `Value` into a `Payload`.
+    /// Note that this is a placeholder method. It will disappear very soon.
+    #[deprecated]
+    pub fn from_value_auto(value: &Value) -> Payload {
+        Payload {
+            json: value.to_json()
+        }
+    }
+
+    /// Serialize a `Value` into a `Payload`.
+    pub fn from_value(value: &Value, type_: &Type) -> Result<Payload, Error> {
+        // Placeholder implementation. Future versions will actually use `type_`
+        // for serialization purposes.
+        if value.get_type() != *type_ {
+            return Err(Error::TypeError(TypeError {expected: type_.clone(), got: value.get_type()} ));
+        }
+        Ok(Payload {
+            json: value.to_json()
+        })
+    }
+    pub fn to_value(&self, type_: &Type) -> Result<Value, Error> {
+        // Placeholder implementation. Future versions will actually use `type_`
+        // for deserialization purposes.
+        let value = try!(Value::parse(Path::new(), &self.json).map_err(Error::ParseError));
+        if value.get_type() != *type_ {
+            return Err(Error::TypeError(TypeError {expected: type_.clone(), got: value.get_type()} ));
+        }
+        Ok(value)
+    }
+}
+
+impl ToJSON for Payload {
+    fn to_json(&self) -> JSON {
+        self.json.clone()
+    }
+}
+
+impl ToJSON for (Payload, Type) {
+    fn to_json(&self) -> JSON {
+        self.0.to_json()
+    }
+}
+
+impl Parser<Payload> for Payload {
+    fn description() -> String {
+        "JSON".to_owned()
+    }
+    fn parse(_: Path, source: &JSON) -> Result<Self, ParseError> {
+        Ok(Payload {
+            json: source.clone()
+        })
+    }
+}

--- a/components/taxonomy/src/lib.rs
+++ b/components/taxonomy/src/lib.rs
@@ -60,3 +60,6 @@ pub mod tag_storage;
 /// Implementation of a fake adapter, controlled entirely programmatically. Designed to be used
 /// as a component of tests.
 pub mod fake_adapter;
+
+/// Serialization and deserialization.
+pub mod io;

--- a/components/taxonomy/src/selector.rs
+++ b/components/taxonomy/src/selector.rs
@@ -138,7 +138,7 @@ impl Parser<ServiceSelector> for ServiceSelector {
     fn description() -> String {
         "ServiceSelector".to_owned()
     }
-    fn parse(path: Path, source: &mut JSON) -> Result<Self, ParseError> {
+    fn parse(path: Path, source: &JSON) -> Result<Self, ParseError> {
         let mut is_empty = true;
         let id = try!(match path.push("id", |path| Exactly::take_opt(path, source, "id")) {
             None => Ok(Exactly::Always),
@@ -354,7 +354,7 @@ impl Parser<ChannelSelector> for ChannelSelector {
     fn description() -> String {
         "ChannelSelector".to_owned()
     }
-    fn parse(path: Path, source: &mut JSON) -> Result<Self, ParseError> {
+    fn parse(path: Path, source: &JSON) -> Result<Self, ParseError> {
         let mut is_empty = true;
         let id = try!(match path.push("id", |path| Exactly::take_opt(path, source, "id")) {
             None => Ok(Exactly::Always),

--- a/components/taxonomy/src/services.rs
+++ b/components/taxonomy/src/services.rs
@@ -471,7 +471,7 @@ impl Parser<ChannelKind> for ChannelKind {
         "ChannelKind".to_owned()
     }
     /// Parse a single value from JSON, consuming as much as necessary from JSON.
-    fn parse(path: Path, source: &mut JSON) -> Result<Self, ParseError> {
+    fn parse(path: Path, source: &JSON) -> Result<Self, ParseError> {
         if let Some(str) = source.as_string() {
             return match str {
                 "Ready" => Ok(ChannelKind::Ready),

--- a/components/taxonomy/src/util.rs
+++ b/components/taxonomy/src/util.rs
@@ -30,7 +30,7 @@ impl<T> Parser<Exactly<T>> for Exactly<T> where T: Parser<T> {
         T::description()
     }
     /// Parse a single value from JSON, consuming as much as necessary from JSON.
-    fn parse(path: Path, source: &mut JSON) -> Result<Self, ParseError> {
+    fn parse(path: Path, source: &JSON) -> Result<Self, ParseError> {
         if let JSON::Null = *source {
             Ok(Exactly::Always)
         } else {
@@ -231,7 +231,7 @@ impl<T> Parser<Id<T>> for Id<T> {
         "Id".to_owned()
     }
     /// Parse a single value from JSON, consuming as much as necessary from JSON.
-    fn parse(path: Path, source: &mut JSON) -> Result<Self, ParseError> {
+    fn parse(path: Path, source: &JSON) -> Result<Self, ParseError> {
         if let JSON::String(ref string) = *source {
             Ok(Id::new(string))
         } else {

--- a/components/taxonomy/src/values.rs
+++ b/components/taxonomy/src/values.rs
@@ -105,7 +105,7 @@ impl Parser<Type> for Type {
     fn description() -> String {
         "Type".to_owned()
     }
-    fn parse(path: Path, source: &mut JSON) -> Result<Self, ParseError> {
+    fn parse(path: Path, source: &JSON) -> Result<Self, ParseError> {
         use self::Type::*;
         match *source {
             JSON::String(ref string) => match &*string as &str {
@@ -237,7 +237,7 @@ impl Parser<OnOff> for OnOff {
     fn description() -> String {
         "OnOff".to_owned()
     }
-    fn parse(path: Path, source: &mut JSON) -> Result<Self, ParseError> {
+    fn parse(path: Path, source: &JSON) -> Result<Self, ParseError> {
         match source.as_string() {
             Some("On") => Ok(OnOff::On),
             Some("Off") => Ok(OnOff::Off),
@@ -368,7 +368,7 @@ impl Parser<OpenClosed> for OpenClosed {
     fn description() -> String {
         "OpenClosed".to_owned()
     }
-    fn parse(path: Path, source: &mut JSON) -> Result<Self, ParseError> {
+    fn parse(path: Path, source: &JSON) -> Result<Self, ParseError> {
         match source.as_string() {
             Some("Open") => Ok(OpenClosed::Open),
             Some("Closed") => Ok(OpenClosed::Closed),
@@ -499,7 +499,7 @@ impl Parser<DoorLocked> for DoorLocked {
     fn description() -> String {
         "DoorLocked".to_owned()
     }
-    fn parse(path: Path, source: &mut JSON) -> Result<Self, ParseError> {
+    fn parse(path: Path, source: &JSON) -> Result<Self, ParseError> {
         match source.as_string() {
             Some("Locked") => Ok(DoorLocked::Locked),
             Some("Unlocked") => Ok(DoorLocked::Unlocked),
@@ -630,7 +630,7 @@ impl Parser<IsSecure> for IsSecure {
     fn description() -> String {
         "IsSecure".to_string()
     }
-    fn parse(path: Path, source: &mut JSON) -> Result<Self, ParseError> {
+    fn parse(path: Path, source: &JSON) -> Result<Self, ParseError> {
         match source.as_string() {
             Some("Insecure") => Ok(IsSecure::Insecure),
             Some("Secure") => Ok(IsSecure::Secure),
@@ -788,7 +788,7 @@ impl Parser<Temperature> for Temperature {
     fn description() -> String {
         "Temperature".to_owned()
     }
-    fn parse(path: Path, source: &mut JSON) -> Result<Self, ParseError> {
+    fn parse(path: Path, source: &JSON) -> Result<Self, ParseError> {
         if !source.is_object() {
             return Err(ParseError::type_error("Temperature", &path, "object"));
         }
@@ -889,7 +889,7 @@ impl Parser<Color> for Color {
     fn description() -> String {
         "Color".to_owned()
     }
-    fn parse(path: Path, source: &mut JSON) -> Result<Self, ParseError> {
+    fn parse(path: Path, source: &JSON) -> Result<Self, ParseError> {
         let h = try!(path.push("h", |path| f64::take(path, source, "h")));
         let s = try!(path.push("s", |path| f64::take(path, source, "s")));
         let v = try!(path.push("v", |path| f64::take(path, source, "v")));
@@ -924,7 +924,7 @@ impl Parser<WebPushNotify> for WebPushNotify {
     fn description() -> String {
         "WebPushNotify".to_owned()
     }
-    fn parse(path: Path, source: &mut JSON) -> Result<Self, ParseError> {
+    fn parse(path: Path, source: &JSON) -> Result<Self, ParseError> {
         let resource = try!(path.push("resource", |path| String::take(path, source, "resource")));
         let message = try!(path.push("message", |path| String::take(path, source, "message")));
         Ok(WebPushNotify { resource: resource, message: message})
@@ -950,7 +950,7 @@ impl Parser<ThinkerbellRule> for ThinkerbellRule {
     fn description() -> String {
         "ThinkerbellRuleSource".to_owned()
     }
-    fn parse(path: Path, source: &mut JSON) -> Result<Self, ParseError> {
+    fn parse(path: Path, source: &JSON) -> Result<Self, ParseError> {
         let name = try!(path.push("name", |path| String::take(path, source, "name")));
         let script_source = try!(path.push("source", |path| String::take(path, source, "source")));
         Ok(ThinkerbellRule { name: name, source: script_source })
@@ -976,7 +976,7 @@ impl Parser<Json> for Json {
     fn description() -> String {
         "Json value".to_owned()
     }
-    fn parse(_: Path, source: &mut JSON) -> Result<Self, ParseError> {
+    fn parse(_: Path, source: &JSON) -> Result<Self, ParseError> {
         Ok(Json(source.clone()))
     }
 }
@@ -1021,7 +1021,7 @@ impl<T> Parser<ExtValue<T>> for ExtValue<T>
     fn description() -> String {
         format!("ExtValue<{}>", T::description())
     }
-    fn parse(path: Path, source: &mut JSON) -> Result<Self, ParseError> {
+    fn parse(path: Path, source: &JSON) -> Result<Self, ParseError> {
         let vendor = try!(path.push("vendor", |path| Id::take(path, source, "vendor")));
         let adapter = try!(path.push("adapter", |path| Id::take(path, source, "adapter")));
         let kind = try!(path.push("kind", |path| Id::take(path, source, "kind")));
@@ -1092,7 +1092,7 @@ impl Parser<Binary> for Binary {
     fn description() -> String {
         "Binary".to_owned()
     }
-    fn parse(path: Path, source: &mut JSON) -> Result<Self, ParseError> {
+    fn parse(path: Path, source: &JSON) -> Result<Self, ParseError> {
         let data = try!(path.push("data", |path| Vec::<u8>::take(path, source, "data")));
         let mimetype = try!(path.push("mimetype", |path| Id::take(path, source, "mimetype")));
         Ok(Binary {
@@ -1609,11 +1609,11 @@ pub enum Value {
 
 lazy_static! {
     static ref VALUE_PARSER:
-        HashMap<&'static str, Box<Fn(Path, &mut JSON) -> Result<Value, ParseError> + Sync>> =
+        HashMap<&'static str, Box<Fn(Path, &JSON) -> Result<Value, ParseError> + Sync>> =
     {
         use self::Value::*;
         use std::string::String as StdString;
-        let mut map : HashMap<&'static str, Box<Fn(Path, &mut JSON) -> Result<Value, ParseError> + Sync>> = HashMap::new();
+        let mut map : HashMap<&'static str, Box<Fn(Path, &JSON) -> Result<Value, ParseError> + Sync>> = HashMap::new();
         map.insert("Unit", Box::new(|_, _| Ok(Unit)));
         map.insert("OnOff", Box::new(|path, v| {
             let value = try!(path.push("OnOff", |path| self::OnOff::parse(path, v)));
@@ -1691,12 +1691,12 @@ impl Parser<Value> for Value {
     fn description() -> String {
         "Value".to_owned()
     }
-    fn parse(path: Path, source: &mut JSON) -> Result<Self, ParseError> {
+    fn parse(path: Path, source: &JSON) -> Result<Self, ParseError> {
         match *source {
             JSON::Null => Ok(Value::Unit),
             JSON::String(ref str) if &*str == "Unit" => Ok(Value::Unit),
-            JSON::Object(ref mut obj) if obj.len() == 1 => {
-                let mut vec : Vec<_> = obj.iter_mut().collect();
+            JSON::Object(ref obj) if obj.len() == 1 => {
+                let mut vec : Vec<_> = obj.iter().collect();
                 let (k, v) = vec.pop().unwrap(); // We checked the length just above.
                 match VALUE_PARSER.get(&k as &str) {
                     None => Err(ParseError::type_error("Value", &path, &&*self::VALUE_KEYS)),
@@ -1886,7 +1886,7 @@ impl Parser<TimeStamp> for TimeStamp {
     fn description() -> String {
         "TimeStamp".to_owned()
     }
-    fn parse(path: Path, source: &mut JSON) -> Result<Self, ParseError> {
+    fn parse(path: Path, source: &JSON) -> Result<Self, ParseError> {
         if let JSON::String(ref str) = *source {
             if let Ok(dt) = DateTime::<UTC>::from_str(str) {
                 return Ok(TimeStamp(dt));
@@ -1993,20 +1993,20 @@ impl Parser<Range> for Range {
     fn description() -> String {
         "Range".to_owned()
     }
-    fn parse(path: Path, source: &mut JSON) -> Result<Self, ParseError> {
+    fn parse(path: Path, source: &JSON) -> Result<Self, ParseError> {
         use self::Range::*;
         match *source {
-            JSON::Object(ref mut obj) if obj.len() == 1 => {
-                if let Some(leq) = obj.get_mut("Leq") {
+            JSON::Object(ref obj) if obj.len() == 1 => {
+                if let Some(leq) = obj.get("Leq") {
                     return Ok(Leq(try!(path.push("Leq", |path| Value::parse(path, leq)))))
                 }
-                if let Some(geq) = obj.get_mut("Geq") {
+                if let Some(geq) = obj.get("Geq") {
                     return Ok(Geq(try!(path.push("Geq", |path| Value::parse(path, geq)))))
                 }
-                if let Some(eq) = obj.get_mut("Eq") {
+                if let Some(eq) = obj.get("Eq") {
                     return Ok(Eq(try!(path.push("eq", |path| Value::parse(path, eq)))))
                 }
-                if let Some(between) = obj.get_mut("BetweenEq") {
+                if let Some(between) = obj.get("BetweenEq") {
                     let mut bounds = try!(path.push("BetweenEq", |path| Vec::<Value>::parse(path, between)));
                     if bounds.len() == 2 {
                         let max = bounds.pop().unwrap();
@@ -2019,7 +2019,7 @@ impl Parser<Range> for Range {
                         return Err(ParseError::type_error("BetweenEq", &path, "an array of two values"))
                     }
                 }
-                if let Some(outof) = obj.get_mut("OutOfStrict") {
+                if let Some(outof) = obj.get("OutOfStrict") {
                     let mut bounds = try!(path.push("OutOfStrict", |path| Vec::<Value>::parse(path, outof)));
                     if bounds.len() == 2 {
                         let max = bounds.pop().unwrap();
@@ -2124,7 +2124,7 @@ impl Parser<Duration> for Duration {
     fn description() -> String {
         "Duration".to_owned()
     }
-    fn parse(path: Path, source: &mut JSON) -> Result<Self, ParseError> {
+    fn parse(path: Path, source: &JSON) -> Result<Self, ParseError> {
         let val = try!(f64::parse(path, source));
         Ok(Duration(ChronoDuration::milliseconds((val * 1000.) as i64)))
     }

--- a/components/thinkerbell/src/compile.rs
+++ b/components/thinkerbell/src/compile.rs
@@ -158,13 +158,6 @@ impl<Env> Compiler<Env> where Env: ExecutableDevEnv {
         if match_.source.len() == 0 {
             return Err(Error::SourceError(SourceError::NoMatchSource));
         }
-        let typ = match match_.range.get_type() {
-            Err(_) => return Err(Error::TypeError(TypeError::InvalidRange)),
-            Ok(typ) => typ
-        };
-        if match_.kind.get_type() != typ {
-            return Err(Error::TypeError(TypeError::KindAndRangeDoNotAgree));
-        }
         let source = match_.source
             .iter()
             .map(|input| input.clone()
@@ -184,9 +177,6 @@ impl<Env> Compiler<Env> where Env: ExecutableDevEnv {
     {
         if statement.destination.len() == 0 {
             return Err(Error::SourceError(SourceError::NoStatementDestination));
-        }
-        if statement.kind.get_type() != statement.value.get_type() {
-            return Err(Error::TypeError(TypeError::KindAndValueDoNotAgree));
         }
         let destination = statement.destination
             .iter()

--- a/components/thinkerbell/src/fake_env.rs
+++ b/components/thinkerbell/src/fake_env.rs
@@ -38,7 +38,7 @@ struct TestSharedAdapterBackend {
     timers: BinaryHeap<Timer>,
     trigger_timers_until: Option<DateTime<UTC>>,
 
-    watchers: HashMap<usize, (Id<Channel>, Option<Box<Range>>, Box<ExtSender<WatchEvent>>)>,
+    watchers: HashMap<usize, (Id<Channel>, Option<Box<Range>>, Box<ExtSender<WatchEvent<Value>>>)>,
 }
 
 impl TestSharedAdapterBackend {
@@ -83,7 +83,7 @@ impl TestSharedAdapterBackend {
         }).collect()
     }
 
-    fn register_watch(&mut self, mut source: Vec<(Id<Channel>, Option<Value>, Box<ExtSender<WatchEvent>>)>) ->
+    fn register_watch(&mut self, mut source: Vec<(Id<Channel>, Option<Value>, Box<ExtSender<WatchEvent<Value>>>)>) ->
             Vec<(Id<Channel>, Result<usize, Error>)>
     {
         let results = source.drain(..).filter_map(|(id, range, tx)| {
@@ -320,7 +320,7 @@ impl Adapter for TestAdapter {
     /// If no `Range` option is set, the watcher expects to receive `EnterRange` events whenever
     /// a new value is available on the device. The adapter may decide to reject the request if
     /// this is clearly not the expected usage for a device, or to throttle it.
-    fn register_watch(&self, source: Vec<(Id<Channel>, Option<Value>, Box<ExtSender<WatchEvent>>)>) ->
+    fn register_watch(&self, source: Vec<(Id<Channel>, Option<Value>, Box<ExtSender<WatchEvent<Value>>>)>) ->
             Vec<(Id<Channel>, Result<Box<AdapterWatchGuard>, Error>)>
     {
         let (tx, rx) = channel();
@@ -545,7 +545,7 @@ enum AdapterOp {
         tx: Box<ExtSender<ResultMap<Id<Channel>, (), Error>>>
     },
     Watch {
-        source: Vec<(Id<Channel>, Option<Value>, Box<ExtSender<WatchEvent>>)>,
+        source: Vec<(Id<Channel>, Option<Value>, Box<ExtSender<WatchEvent<Value>>>)>,
         tx: Box<ExtSender<Vec<(Id<Channel>, Result<usize, Error>)>>>
     },
     AddTimer(Timer),

--- a/components/thinkerbell/tests/test_rules.rs
+++ b/components/thinkerbell/tests/test_rules.rs
@@ -10,6 +10,7 @@ use foxbox_thinkerbell::run::*;
 use foxbox_thinkerbell::ast::*;
 
 use foxbox_taxonomy::api::{ Error as APIError, User };
+use foxbox_taxonomy::io::*;
 use foxbox_taxonomy::selector::*;
 use foxbox_taxonomy::services::*;
 use foxbox_taxonomy::values::{ Duration, OnOff, Range, TimeStamp, Type, TypeError as APITypeError , Value };
@@ -78,6 +79,8 @@ fn test_run() {
     let env = FakeEnv::new(tx_env);
     let mut exec = Execution::<FakeEnv>::new();
 
+    let data_off = Payload::from_value(&Value::OnOff(OnOff::Off), &Type::OnOff).unwrap();
+
     println!("* Spawning thread.");
     thread::spawn(move || {
         for msg in rx {
@@ -113,7 +116,7 @@ fn test_run() {
                         destination: vec![
                             ChannelSelector::new()
                         ],
-                        value: Value::OnOff(OnOff::Off),
+                        value: data_off,
                         kind: ChannelKind::LightOn,
                         phantom: PhantomData,
                     }
@@ -460,6 +463,8 @@ fn test_run_with_delay() {
     let env = FakeEnv::new(tx_env);
     let mut exec = Execution::<FakeEnv>::new();
 
+    let data_off = Payload::from_value(&Value::OnOff(OnOff::Off), &Type::OnOff).unwrap();
+
     thread::spawn(move || {
         for msg in rx {
             if let Event::Env(FakeEnvEvent::Done) = msg {
@@ -497,7 +502,7 @@ fn test_run_with_delay() {
                         destination: vec![
                             ChannelSelector::new()
                         ],
-                        value: Value::OnOff(OnOff::Off),
+                        value: data_off,
                         kind: ChannelKind::LightOn,
                         phantom: PhantomData,
                     }

--- a/src/adapters/clock/mod.rs
+++ b/src/adapters/clock/mod.rs
@@ -2,7 +2,7 @@
 //! timestamp or the current time of day.
 
 use foxbox_taxonomy::manager::*;
-use foxbox_taxonomy::api::{ Error, InternalError, User };
+use foxbox_taxonomy::api::{ Error, InternalError, Operation, User };
 use foxbox_taxonomy::values::{ Duration as ValDuration, Range, TimeStamp, Type, Value };
 use foxbox_taxonomy::services::*;
 
@@ -134,7 +134,7 @@ impl Clock {
             _ if *id == self.getter_time_of_day_id => self.aux_register_watch_timeofday(id, range, tx),
             _ if *id == self.getter_timestamp_id => self.aux_register_watch_timestamp(id, range, tx),
             _ if *id == self.getter_interval_id => self.aux_register_watch_interval(id, range, tx),
-            _ => Err(Error::GetterDoesNotSupportWatching(id.clone()))
+            _ => Err(Error::OperationNotSupported(Operation::Watch, id.clone()))
         }
     }
 

--- a/src/adapters/console/mod.rs
+++ b/src/adapters/console/mod.rs
@@ -74,13 +74,6 @@ impl Adapter for Console {
             })
             .collect()
     }
-
-    fn register_watch(&self, mut watch: Vec<WatchTarget>) -> WatchResult
-    {
-        watch.drain(..).map(|(id, _, _)| {
-            (id.clone(), Err(Error::GetterDoesNotSupportWatching(id)))
-        }).collect()
-    }
 }
 
 

--- a/src/adapters/ip_camera/mod.rs
+++ b/src/adapters/ip_camera/mod.rs
@@ -285,11 +285,4 @@ impl Adapter for IPCameraAdapter {
             (id.clone(), Err(Error::InternalError(InternalError::NoSuchChannel(id))))
         }).collect()
     }
-
-    fn register_watch(&self, mut watch: Vec<WatchTarget>) -> WatchResult
-    {
-        watch.drain(..).map(|(id, _, _)| {
-            (id.clone(), Err(Error::GetterDoesNotSupportWatching(id)))
-        }).collect()
-    }
 }

--- a/src/adapters/philips_hue/mod.rs
+++ b/src/adapters/philips_hue/mod.rs
@@ -297,10 +297,4 @@ impl<C: Controller> Adapter for PhilipsHueAdapter<C> {
             (id.clone(), Err(Error::InternalError(InternalError::NoSuchChannel(id))))
         }).collect()
     }
-
-    fn register_watch(&self, mut watch: Vec<WatchTarget>) -> WatchResult {
-        watch.drain(..).map(|(id, _, _)| {
-            (id.clone(), Err(Error::GetterDoesNotSupportWatching(id)))
-        }).collect()
-    }
 }

--- a/src/adapters/thinkerbell/mod.rs
+++ b/src/adapters/thinkerbell/mod.rs
@@ -133,13 +133,6 @@ impl Adapter for ThinkerbellAdapter {
             })
             .collect()
     }
-
-    fn register_watch(&self, mut watch: Vec<WatchTarget>) -> WatchResult
-    {
-        watch.drain(..).map(|(id, _, _)| {
-            (id.clone(), Err(Error::GetterDoesNotSupportWatching(id)))
-        }).collect()
-    }
 }
 
 /// `ThinkerbellAdapter`'s main loop handles messages of these types.

--- a/src/adapters/tts/mod.rs
+++ b/src/adapters/tts/mod.rs
@@ -12,7 +12,7 @@ use foxbox_taxonomy::manager::AdapterManager;
 use foxbox_taxonomy::api::{ Error, InternalError, User };
 use foxbox_taxonomy::services::{ AdapterId, Channel, ChannelKind, Id, Service, ServiceId };
 use foxbox_taxonomy::values::{ Type, Value };
-use std::collections::{ HashMap, HashSet };
+use std::collections::HashMap;
 use std::sync::Arc;
 use transformable_channels::mpsc::*;
 
@@ -67,13 +67,6 @@ impl<T: TtsEngine> Adapter for TtsAdapter<T> {
                 }
             }
             (id.clone(), Err(Error::InternalError(InternalError::NoSuchChannel(id))))
-        }).collect()
-    }
-
-    fn register_watch(&self, mut watch: Vec<WatchTarget>) -> WatchResult
-    {
-        watch.drain(..).map(|(id, _, _)| {
-            (id.clone(), Err(Error::GetterDoesNotSupportWatching(id)))
         }).collect()
     }
 }

--- a/src/adapters/webpush/mod.rs
+++ b/src/adapters/webpush/mod.rs
@@ -297,13 +297,6 @@ impl<C: Controller> Adapter for WebPush<C> {
             (id.clone(), Err(Error::InternalError(InternalError::NoSuchChannel(id))))
         }).collect()
     }
-
-    fn register_watch(&self, mut watch: Vec<WatchTarget>) -> WatchResult
-    {
-        watch.drain(..).map(|(id, _, _)| {
-            (id.clone(), Err(Error::GetterDoesNotSupportWatching(id)))
-        }).collect()
-    }
 }
 
 impl<C: Controller> WebPush<C> {

--- a/test/integration/test/philips_color_test.js
+++ b/test/integration/test/philips_color_test.js
@@ -68,36 +68,38 @@ Prepper.makeSuite('Control lights locally',function(){
     var hue = 200;
     var invalidSat = 1.5;  // range = [0,1]
     var bri = 0.5;
-    
+
     // send various values within valid range
     var payload = {'select': {'id': lights[0]}, 
       'value': { 'Color': {'h':hue,'s':invalidSat,'v':bri} } };
 
     return chakram.put(Prepper.foxboxManager.setterURL,payload)
     .then(function(cmdResponse) {
-      expect(cmdResponse).to.have.status(400);
-      expect(cmdResponse.body).equals(
-        'TypeError { name: "s", at: "body.value.Color.Color",' +
-         ' expected: "a number in [0, 1]" }');
+      expect(cmdResponse).to.have.status(200);
+      expect(cmdResponse.body[lights[0]].Error.ParseError.TypeError.expected)
+        .equals("a number in [0, 1]");
+      expect(cmdResponse.body[lights[0]].Error.ParseError.TypeError.name)
+        .equals("s");
     });
-  }); 
+  });
 
   it('Send invalid brightness value', function() {   
     lights[1] = lights[1].replace('getter:power','setter:color');
     var hue = 200;
     var sat = 0.5;  // range = [0,1]
-    var invalidBri = 1.5;  // Value should be less than or equal to 1 
-    
+    var invalidBri = 1.5;  // Value should be less than or equal to 1
+
     // send various values within valid range
     var payload = {'select': {'id': lights[1]}, 
       'value': { 'Color': {'h':hue,'s':sat,'v':invalidBri} } };
 
     return chakram.put(Prepper.foxboxManager.setterURL,payload)
     .then(function(cmdResponse) {
-      expect(cmdResponse).to.have.status(400);
-      expect(cmdResponse.body).equals(
-        'TypeError { name: "v", at: "body.value.Color.Color",' + 
-        ' expected: "a number in [0, 1]" }');
+      expect(cmdResponse).to.have.status(200);
+      expect(cmdResponse.body[lights[1]].Error.ParseError.TypeError.expected)
+        .equals("a number in [0, 1]");
+      expect(cmdResponse.body[lights[1]].Error.ParseError.TypeError.name)
+        .equals("v");
     });
-  }); 
+  });
 });


### PR DESCRIPTION
This has two aims:
1. this will help us progressively remove the big centralized enums (`ChannelKind`, `Type`, `Value`);
2. this will help adapter developers write off-process adapters.
