### PR TITLE
Decentralizing: Removing big centralized Type

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16,6 +16,7 @@ dependencies = [
  "iron 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "iron-cors 0.1.0 (git+https://github.com/fxbox/iron-cors.git?rev=f397cd2)",
  "iron-test 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "mio 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ env_logger = "0.3.2"
 #get_if_addrs = "0.3.1"
 get_if_addrs = { git = "https://github.com/dhylands/get_if_addrs", rev = "23632fd3473d42d3dc5710fc7855c5979b10ce50" } # Temporary until get_if_addrs PR to update to libc 0.2 is merged
 hyper = "0.8.1"
+lazy_static = "^0.1"
 libc = "0.2.7"
 log = "0.3"
 mio = "0.5.1"

--- a/components/openzwave-adapter/src/lib.rs
+++ b/components/openzwave-adapter/src/lib.rs
@@ -192,7 +192,7 @@ fn start_including(ozw: &ZWaveManager, home_id: u32, value: &Value) -> Result<()
             info!("[OpenZWaveAdapter] Controller on network {} is awaiting an include in {} mode, please do the appropriate steps to include a device.", home_id, is_secure);
             Ok(())
         }
-        _ => Err(TaxoError::TypeError(TypeError { expected: Type::IsSecure.name(), got: value.get_type().name() }))
+        _ => Err(TaxoError::TypeError(TypeError::new(&format::IS_SECURE, &value)))
     }
 }
 
@@ -327,7 +327,7 @@ impl OpenzwaveAdapter {
 
                         box_manager.add_channel(Channel {
                             feature: TaxoId::new("zwave/include"),
-                            supports_send: Some(Signature::accepts(Maybe::Required(Type::IsSecure))),
+                            supports_send: Some(Signature::accepts(Maybe::Required(format::IS_SECURE.clone()))),
                             id: include_setter_id.clone(),
                             service: service_id.clone(),
                             adapter: adapter_id.clone(),

--- a/components/taxonomy/src/adapter.rs
+++ b/components/taxonomy/src/adapter.rs
@@ -115,12 +115,12 @@ pub trait RawAdapter: Send + Sync {
     /// reboots/reconnections.
     fn id(&self) -> Id<AdapterId>;
 
-    fn fetch_values(&self, mut target: Vec<(Id<Channel>, Type)>, _: User) -> ResultMap<Id<Channel>, Option<(Payload, Type)>, Error> {
+    fn fetch_values(&self, mut target: Vec<(Id<Channel>, Arc<Format>)>, _: User) -> ResultMap<Id<Channel>, Option<(Payload, Arc<Format>)>, Error> {
         target.drain(..).map(|(id, _)| {
             (id.clone(), Err(Error::OperationNotSupported(Operation::Watch, id)))
         }).collect()
     }
-    fn send_values(&self, mut values: HashMap<Id<Channel>, (Payload, Type)>, _: User) -> ResultMap<Id<Channel>, (), Error> {
+    fn send_values(&self, mut values: HashMap<Id<Channel>, (Payload, Arc<Format>)>, _: User) -> ResultMap<Id<Channel>, (), Error> {
         values.drain().map(|(id, _)| {
             (id.clone(), Err(Error::OperationNotSupported(Operation::Watch, id)))
         }).collect()
@@ -167,7 +167,7 @@ pub trait Adapter: Send + Sync {
     /// expects the adapter to attempt to minimize the connections with the actual devices.
     ///
     /// The AdapterManager is in charge of keeping track of the age of values.
-    fn fetch_values(&self, mut target: Vec<Id<Channel>>, _: User) -> ResultMap<Id<Channel>, Option<Value>, Error>
+    fn fetch_values(&self, mut target: Vec<Id<Channel>>, _: User) -> OpResult<Value>
     {
         target.drain(..).map(|id| {
             (id.clone(), Err(Error::OperationNotSupported(Operation::Watch, id)))
@@ -209,7 +209,8 @@ pub trait Adapter: Send + Sync {
     }
 }
 
-pub type RawWatchTarget = (Id<Channel>, /*condition*/Option<(Payload, Type)>, /*values*/Type, Box<ExtSender<WatchEvent</*result*/(Payload, Type)>>>);
+pub type OpResult<T> = ResultMap<Id<Channel>, Option<T>, Error>;
+pub type RawWatchTarget = (Id<Channel>, /*condition*/Option<(Payload, Arc<Format>)>, /*values*/Arc<Format>, Box<ExtSender<WatchEvent</*result*/(Payload, Arc<Format>)>>>);
 pub type WatchTarget = (Id<Channel>, /*condition*/Option<Value>, Box<ExtSender<WatchEvent</*result*/Value>>>);
 
 pub type WatchResult = Vec<(Id<Channel>, Result<Box<AdapterWatchGuard>, Error>)>;

--- a/components/taxonomy/src/adapter_utils.rs
+++ b/components/taxonomy/src/adapter_utils.rs
@@ -83,7 +83,7 @@ impl RawAdapter for RawAdapterForAdapter {
     fn stop(&self) {
         self.adapter.stop()
     }
-    fn fetch_values(&self, mut target: Vec<(Id<Channel>, Type)>, user: User) -> ResultMap<Id<Channel>, Option<(Payload, Type)>, Error> {
+    fn fetch_values(&self, mut target: Vec<(Id<Channel>, Arc<Format>)>, user: User) -> OpResult<(Payload, Arc<Format>)> {
         let types : HashMap<_, _> = target.iter().cloned().collect();
         let channels : Vec<_> = target.drain(..).map(|(id, _)| id).collect();
         let values = self.adapter.fetch_values(channels, user);
@@ -103,7 +103,7 @@ impl RawAdapter for RawAdapterForAdapter {
         }).collect()
     }
 
-    fn send_values(&self, mut values: HashMap<Id<Channel>, (Payload, Type)>, user: User) -> ResultMap<Id<Channel>, (), Error> {
+    fn send_values(&self, mut values: HashMap<Id<Channel>, (Payload, Arc<Format>)>, user: User) -> ResultMap<Id<Channel>, (), Error> {
         let mut send = HashMap::new();
         let mut failures = HashMap::new();
         for (id, (payload, type_)) in values.drain() {

--- a/components/taxonomy/src/channel.rs
+++ b/components/taxonomy/src/channel.rs
@@ -1,19 +1,21 @@
+use io::*;
 use parse::*;
 use util::*;
-use values::Type;
+use values::*;
 
 use std::collections::HashSet;
 use std::hash::{ Hash, Hasher };
+use std::sync::Arc;
 
 
 #[derive(Debug, Clone)]
 pub struct Signature {
-    pub accepts: Maybe<Type>,
-    pub returns: Maybe<Type>
+    pub accepts: Maybe<Arc<Format>>,
+    pub returns: Maybe<Arc<Format>>
 }
 impl Signature {
     /// Shortcut for building a signature that accepts some arg, returns nothing.
-    pub fn accepts(spec: Maybe<Type>) -> Self {
+    pub fn accepts(spec: Maybe<Arc<Format>>) -> Self {
         Signature {
             accepts: spec,
             returns: Maybe::Nothing
@@ -21,7 +23,7 @@ impl Signature {
     }
 
     /// Shortcut for building a signature that accepts nothing, returns some value.
-    pub fn returns(spec: Maybe<Type>) -> Self {
+    pub fn returns(spec: Maybe<Arc<Format>>) -> Self {
         Signature {
             returns: spec,
             accepts: Maybe::Nothing
@@ -43,8 +45,12 @@ impl ToJSON for Signature {
             let spec;
             match *value {
                 Maybe::Nothing => continue,
-                Maybe::Required(ref type_) => spec = vec![("requires", type_.to_json())],
-                Maybe::Optional(ref type_) => spec = vec![("optional", type_.to_json())]
+                Maybe::Required(ref format) => {
+                    spec = vec![("requires", format.description())]
+                },
+                Maybe::Optional(ref format) => {
+                    spec = vec![("optional", format.description())]
+                }
             }
             vec.push((key, spec.to_json()))
         }
@@ -175,9 +181,9 @@ lazy_static! {
     /// - watch this channel to be informed when it is (un)locked.
     pub static ref DOOR_IS_LOCKED : Channel = Channel {
         feature: Id::new("door/is-locked"),
-        supports_send: Some(Signature::accepts(Maybe::Required(Type::OpenClosed))),
-        supports_fetch: Some(Signature::returns(Maybe::Required(Type::OpenClosed))),
-        supports_watch: Some(Signature::returns(Maybe::Required(Type::OpenClosed))),
+        supports_send: Some(Signature::accepts(Maybe::Required(format::OPEN_CLOSED.clone()))),
+        supports_fetch: Some(Signature::returns(Maybe::Required(format::OPEN_CLOSED.clone()))),
+        supports_watch: Some(Signature::returns(Maybe::Required(format::OPEN_CLOSED.clone()))),
         .. Channel::default()
     };
 
@@ -189,9 +195,9 @@ lazy_static! {
     /// - watch this channel to be informed when it is opened/closed.
     pub static ref DOOR_IS_OPEN : Channel = Channel {
         feature: Id::new("door/is-open"),
-        supports_send: Some(Signature::accepts(Maybe::Required(Type::OpenClosed))),
-        supports_fetch: Some(Signature::returns(Maybe::Required(Type::OpenClosed))),
-        supports_watch: Some(Signature::returns(Maybe::Required(Type::OpenClosed))),
+        supports_send: Some(Signature::accepts(Maybe::Required(format::OPEN_CLOSED.clone()))),
+        supports_fetch: Some(Signature::returns(Maybe::Required(format::OPEN_CLOSED.clone()))),
+        supports_watch: Some(Signature::returns(Maybe::Required(format::OPEN_CLOSED.clone()))),
         .. Channel::default()
     };
 
@@ -203,18 +209,18 @@ lazy_static! {
     /// - watch this channel to be informed when it is turned on/off.
     pub static ref LIGHT_IS_ON : Channel = Channel {
         feature: Id::new("light/is-on"),
-        supports_send: Some(Signature::accepts(Maybe::Required(Type::OnOff))),
-        supports_fetch: Some(Signature::returns(Maybe::Required(Type::OnOff))),
-        supports_watch: Some(Signature::returns(Maybe::Required(Type::OnOff))),
+        supports_send: Some(Signature::accepts(Maybe::Required(format::ON_OFF.clone()))),
+        supports_fetch: Some(Signature::returns(Maybe::Required(format::ON_OFF.clone()))),
+        supports_watch: Some(Signature::returns(Maybe::Required(format::ON_OFF.clone()))),
         .. Channel::default()
     };
 
     /// Standardized channel: determine the color of a light.
     pub static ref LIGHT_COLOR_HSV : Channel = Channel {
         feature: Id::new("light/color-hsv"),
-        supports_send: Some(Signature::accepts(Maybe::Required(Type::Color))),
-        supports_fetch: Some(Signature::returns(Maybe::Required(Type::Color))),
-        supports_watch: Some(Signature::returns(Maybe::Required(Type::Color))),
+        supports_send: Some(Signature::accepts(Maybe::Required(format::COLOR.clone()))),
+        supports_fetch: Some(Signature::returns(Maybe::Required(format::COLOR.clone()))),
+        supports_watch: Some(Signature::returns(Maybe::Required(format::COLOR.clone()))),
         .. Channel::default()
     };
 
@@ -224,30 +230,30 @@ lazy_static! {
     /// - send to this channel to log a string.
     pub static ref LOG: Channel = Channel {
         feature: Id::new("log/append-text"),
-        supports_send: Some(Signature::accepts(Maybe::Required(Type::String))),
+        supports_send: Some(Signature::accepts(Maybe::Required(format::STRING.clone()))),
         .. Channel::default()
     };
 
     /// Standardized channel: access the username of a device.
     pub static ref USERNAME: Channel = Channel {
         feature: Id::new("security/username"),
-        supports_send: Some(Signature::accepts(Maybe::Required(Type::String))),
-        supports_fetch: Some(Signature::returns(Maybe::Required(Type::String))),
+        supports_send: Some(Signature::accepts(Maybe::Required(format::STRING.clone()))),
+        supports_fetch: Some(Signature::returns(Maybe::Required(format::STRING.clone()))),
         .. Channel::default()
     };
 
     /// Standardized channel: access the password of a device.
     pub static ref PASSWORD: Channel = Channel {
         feature: Id::new("security/password"),
-        supports_send: Some(Signature::accepts(Maybe::Required(Type::String))),
-        supports_fetch: Some(Signature::returns(Maybe::Required(Type::String))),
+        supports_send: Some(Signature::accepts(Maybe::Required(format::STRING.clone()))),
+        supports_fetch: Some(Signature::returns(Maybe::Required(format::STRING.clone()))),
         .. Channel::default()
     };
 
     /// Standardized channel: determine whether a device is currently accessible.
     pub static ref AVAILABLE: Channel = Channel {
         feature: Id::new("device/available"),
-        supports_fetch: Some(Signature::returns(Maybe::Required(Type::OnOff))),
+        supports_fetch: Some(Signature::returns(Maybe::Required(format::ON_OFF.clone()))),
         .. Channel::default()
     };
 }

--- a/components/taxonomy/src/manager.rs
+++ b/components/taxonomy/src/manager.rs
@@ -13,7 +13,6 @@ use io::*;
 use selector::*;
 use services::*;
 use util::is_sync;
-use values::Type;
 
 use std::collections::HashMap;
 use std::path::PathBuf;
@@ -248,8 +247,7 @@ impl API for AdapterManager {
     }
 
     /// Read the latest value from a set of channels
-    fn fetch_values(&self, selectors: Vec<ChannelSelector>, user: User) ->
-        ResultMap<Id<Channel>, Option<(Payload, Type)>, Error>
+    fn fetch_values(&self, selectors: Vec<ChannelSelector>, user: User) -> OpResult<(Payload, Arc<Format>)>
     {
         // First, prepare the request.
         let mut request;
@@ -290,7 +288,7 @@ impl API for AdapterManager {
     }
 
     /// Watch for any change
-    fn watch_values(&self, watch: TargetMap<ChannelSelector, Exactly<(Payload, Type)>>,
+    fn watch_values(&self, watch: TargetMap<ChannelSelector, Exactly<(Payload, Arc<Format>)>>,
         on_event: Box<ExtSender<api::WatchEvent>>) -> Self::WatchGuard
     {
         let (request, watch_key, is_dropped) =

--- a/components/thinkerbell/src/manager.rs
+++ b/components/thinkerbell/src/manager.rs
@@ -14,7 +14,7 @@ use rusqlite;
 use transformable_channels::mpsc::{ channel, ExtSender, TransformableSender };
 
 /// A ScriptManager error.
-#[derive(Serialize, Debug)]
+#[derive(Debug)]
 pub enum Error {
     /// The script you requested (by ID) does not exist.
     NoSuchScriptError,

--- a/components/thinkerbell/src/run.rs
+++ b/components/thinkerbell/src/run.rs
@@ -10,7 +10,8 @@ use foxbox_taxonomy::api::{ API, Error as APIError, Targetted, User, WatchEvent 
 use foxbox_taxonomy::channel::Channel;
 use foxbox_taxonomy::io::*;
 use foxbox_taxonomy::util::{ Exactly, Id };
-use foxbox_taxonomy::values::{ Duration, Type, Value };
+use foxbox_taxonomy::values::{ Duration, Value };
+use foxbox_taxonomy::values::format;
 
 use transformable_channels::mpsc::*;
 
@@ -264,7 +265,7 @@ impl<Env> ExecutionTask<Env> where Env: ExecutableDevEnv + Debug {
 
                 let rule_index = rule_index.clone();
                 let condition_index = condition_index.clone();
-                let payload_and_type = (Payload::from_value_auto(&Value::Range(Box::new(condition.range.clone()))), Type::Range);
+                let payload_and_type = (Payload::from_value_auto(&Value::Range(Box::new(condition.range.clone()))), format::RANGE.clone());
                 witnesses.push(
                     api.watch_values(
                         vec![Targetted {
@@ -498,14 +499,14 @@ impl<Env> Statement<CompiledCtx<Env>> where Env: ExecutableDevEnv {
 
 
 
-#[derive(Clone, Debug, Serialize)]
+#[derive(Clone, Debug)]
 pub enum StartStopError {
     AlreadyRunning,
     NotRunning,
     ThreadError,
 }
 
-#[derive(Clone, Debug, Serialize)]
+#[derive(Clone, Debug)]
 pub enum Error {
     CompileError(compile::Error),
     StartStopError(StartStopError),

--- a/components/thinkerbell/tests/test_rules.rs
+++ b/components/thinkerbell/tests/test_rules.rs
@@ -14,7 +14,7 @@ use foxbox_taxonomy::channel::*;
 use foxbox_taxonomy::io::*;
 use foxbox_taxonomy::selector::*;
 use foxbox_taxonomy::services::*;
-use foxbox_taxonomy::values::{ Duration, OnOff, Range, TimeStamp, Type, TypeError as APITypeError , Value };
+use foxbox_taxonomy::values::{ format, Duration, OnOff, OpenClosed, Range, TimeStamp, TypeError as APITypeError , Value };
 
 use std::fmt::Debug;
 use std::marker::PhantomData;
@@ -78,7 +78,7 @@ fn test_run() {
     let env = FakeEnv::new(tx_env);
     let mut exec = Execution::<FakeEnv>::new();
 
-    let data_off = Payload::from_value(&Value::OnOff(OnOff::Off), &Type::OnOff).unwrap();
+    let data_off = Payload::from_value(&Value::OnOff(OnOff::Off), &format::ON_OFF).unwrap();
 
     println!("* Spawning thread.");
     thread::spawn(move || {
@@ -189,10 +189,7 @@ fn test_run() {
 
     println!("* Injecting an error does not trigger the send.");
     env.execute(Instruction::InjectGetterValues(vec![
-        (getter_id_1.clone(), Err(APIError::TypeError(APITypeError {
-            expected: Type::OnOff.name(),
-            got: Type::OpenClosed.name()
-        })))
+        (getter_id_1.clone(), Err(APIError::TypeError(APITypeError::new(&format::ON_OFF, &Value::OpenClosed(OpenClosed::Open)))))
     ]));
 
     rx_done.recv().unwrap();
@@ -429,10 +426,7 @@ fn test_run() {
     rx_send.try_recv().unwrap_err();
 
     env.execute(Instruction::InjectSetterErrors(vec![
-        (setter_id_1.clone(), Some(APIError::TypeError(APITypeError {
-            expected: Type::OnOff.name(),
-            got: Type::OpenClosed.name()
-        })))
+        (setter_id_1.clone(), Some(APIError::TypeError(APITypeError::new(&format::ON_OFF, &Value::OpenClosed(OpenClosed::Open)))))
     ]));
     rx_done.recv().unwrap();
     rx_send.try_recv().unwrap_err();
@@ -476,7 +470,7 @@ fn test_run_with_delay() {
     let env = FakeEnv::new(tx_env);
     let mut exec = Execution::<FakeEnv>::new();
 
-    let data_off = Payload::from_value(&Value::OnOff(OnOff::Off), &Type::OnOff).unwrap();
+    let data_off = Payload::from_value(&Value::OnOff(OnOff::Off), &format::ON_OFF).unwrap();
 
     thread::spawn(move || {
         for msg in rx {
@@ -657,10 +651,7 @@ fn test_run_with_delay() {
     rx_send.try_recv().unwrap_err();
 
     env.execute(Instruction::InjectGetterValues(vec![
-        (getter_id_1.clone(), Err(APIError::TypeError(APITypeError {
-            expected: Type::OnOff.name(),
-            got: Type::OpenClosed.name()
-        })))
+        (getter_id_1.clone(), Err(APIError::TypeError(APITypeError::new(&format::ON_OFF, &Value::OpenClosed(OpenClosed::Open)))))
     ]));
     rx_done.recv().unwrap();
     rx_send.try_recv().unwrap_err();

--- a/src/adapters/clock/mod.rs
+++ b/src/adapters/clock/mod.rs
@@ -5,7 +5,7 @@ use foxbox_taxonomy::api::{ Error, InternalError, Operation, User };
 use foxbox_taxonomy::channel::*;
 use foxbox_taxonomy::manager::*;
 use foxbox_taxonomy::services::*;
-use foxbox_taxonomy::values::{ Duration as ValDuration, Range, TimeStamp, Type, Value };
+use foxbox_taxonomy::values::{ format, Duration as ValDuration, Range, TimeStamp, Value };
 
 use transformable_channels::mpsc::*;
 
@@ -13,7 +13,7 @@ use std::collections::HashMap;
 use std::sync::{ Arc, Mutex };
 
 use chrono;
-use chrono::*;
+use chrono::{ DateTime, Duration, Local, NaiveTime, Timelike };
 use timer;
 
 static ADAPTER_NAME: &'static str = "Clock adapter (built-in)";
@@ -334,10 +334,10 @@ impl Clock {
         try!(adapt.add_service(service));
         try!(adapt.add_channel(Channel {
             feature: Id::new("clock/time-of-day-seconds"),
-            supports_fetch: Some(Signature::returns(Maybe::Required(Type::Duration))),
+            supports_fetch: Some(Signature::returns(Maybe::Required(format::DURATION.clone()))),
             supports_watch: Some(Signature {
-                accepts: Maybe::Required(Type::Duration),
-                returns: Maybe::Required(Type::Duration)
+                accepts: Maybe::Required(format::DURATION.clone()),
+                returns: Maybe::Required(format::DURATION.clone())
             }),
             id: getter_time_of_day_id,
             service: service_clock_id.clone(),
@@ -346,10 +346,10 @@ impl Clock {
         }));
         try!(adapt.add_channel(Channel {
             feature: Id::new("clock/time-timestamp-rfc-3339"),
-            supports_fetch: Some(Signature::returns(Maybe::Required(Type::TimeStamp))),
+            supports_fetch: Some(Signature::returns(Maybe::Required(format::TIMESTAMP.clone()))),
             supports_watch: Some(Signature {
-                accepts: Maybe::Required(Type::TimeStamp),
-                returns: Maybe::Required(Type::TimeStamp)
+                accepts: Maybe::Required(format::TIMESTAMP.clone()),
+                returns: Maybe::Required(format::TIMESTAMP.clone())
             }),
             id: getter_timestamp_id,
             service: service_clock_id.clone(),
@@ -359,8 +359,8 @@ impl Clock {
         try!(adapt.add_channel(Channel {
             feature: Id::new("clock/time-interval-seconds"),
             supports_watch: Some(Signature {
-                accepts: Maybe::Required(Type::Duration),
-                returns: Maybe::Required(Type::TimeStamp)
+                accepts: Maybe::Required(format::DURATION.clone()),
+                returns: Maybe::Required(format::TIMESTAMP.clone())
             }),
             id: getter_interval_id,
             service: service_clock_id.clone(),

--- a/src/adapters/ip_camera/mod.rs
+++ b/src/adapters/ip_camera/mod.rs
@@ -17,7 +17,8 @@ use foxbox_taxonomy::api::{Error, InternalError, User};
 use foxbox_taxonomy::channel::*;
 use foxbox_taxonomy::manager::*;
 use foxbox_taxonomy::services::*;
-use foxbox_taxonomy::values::{ Value, Json, Binary, Type, TypeError};
+use foxbox_taxonomy::values::{ Binary, Json, TypeError, Value };
+use foxbox_taxonomy::values::format;
 use self::api::*;
 use self::upnp_listener::IpCameraUpnpListener;
 use std::collections::HashMap;
@@ -118,7 +119,7 @@ impl IPCameraAdapter {
         let getter_image_list_id = create_channel_id("image_list", udn);
         try!(adapt.add_channel(Channel {
             feature: Id::new("camera/x-image-list"),
-            supports_fetch: Some(Signature::returns(Maybe::Required(Type::Json))),
+            supports_fetch: Some(Signature::returns(Maybe::Required(format::JSON.clone()))),
             id: getter_image_list_id.clone(),
             service: service_id.clone(),
             adapter: adapter_id.clone(),
@@ -128,7 +129,7 @@ impl IPCameraAdapter {
         let getter_image_newest_id = create_channel_id("image_newest", udn);
         try!(adapt.add_channel(Channel {
             feature: Id::new("camera/x-latest-image"),
-            supports_fetch: Some(Signature::returns(Maybe::Required(Type::Binary))),
+            supports_fetch: Some(Signature::returns(Maybe::Required(format::BINARY.clone()))),
             id: getter_image_newest_id.clone(),
             service: service_id.clone(),
             adapter: adapter_id.clone(),
@@ -245,8 +246,8 @@ impl Adapter for IPCameraAdapter {
                     return (id, Ok(()));
                 }
                 return (id, Err(Error::TypeError(TypeError {
-                                got:value.get_type().name(),
-                                expected: Type::String.name()
+                                got: value.description(),
+                                expected: format::STRING.description()
                             })))
             }
 
@@ -256,8 +257,8 @@ impl Adapter for IPCameraAdapter {
                     return (id, Ok(()));
                 }
                 return (id, Err(Error::TypeError(TypeError {
-                                got:value.get_type().name(),
-                                expected: Type::String.name()
+                                got: value.description(),
+                                expected: format::STRING.description()
                             })))
             }
 

--- a/src/adapters/philips_hue/mod.rs
+++ b/src/adapters/philips_hue/mod.rs
@@ -22,7 +22,7 @@ use foxbox_taxonomy::api::{ Error, InternalError, User };
 use foxbox_taxonomy::channel::*;
 use foxbox_taxonomy::manager::*;
 use foxbox_taxonomy::services::*;
-use foxbox_taxonomy::values::{ Color, OnOff, Type, TypeError, Value };
+use foxbox_taxonomy::values::{ format, Color, OnOff, TypeError, Value };
 
 use std::collections::HashMap;
 use std::sync::{ Arc, Mutex };
@@ -270,10 +270,7 @@ impl<C: Controller> Adapter for PhilipsHueAdapter<C> {
                     Value::OnOff(OnOff::On)  => { light.set_power(true); },
                     Value::OnOff(OnOff::Off) => { light.set_power(false); },
                     _ => {
-                        return (id, Err(Error::TypeError(TypeError {
-                                        got: value.get_type().name(),
-                                        expected: Type::OnOff.name()
-                                    })));
+                        return (id, Err(Error::TypeError(TypeError::new(&format::ON_OFF, &value))));
                     }
                 }
                 return (id, Ok(()));
@@ -282,10 +279,7 @@ impl<C: Controller> Adapter for PhilipsHueAdapter<C> {
                 match value {
                     Value::Color(Color::HSV(h, s, v)) => { light.set_color((h, s, v)); },
                     _ => {
-                        return (id, Err(Error::TypeError(TypeError {
-                                        got: value.get_type().name(),
-                                        expected: Type::Color.name()
-                                    })));
+                        return (id, Err(Error::TypeError(TypeError::new(&format::COLOR, &value) )));
                     }
                 }
                 return (id, Ok(()));

--- a/src/adapters/tts/mod.rs
+++ b/src/adapters/tts/mod.rs
@@ -13,7 +13,7 @@ use foxbox_taxonomy::api::{ Error, InternalError, User };
 use foxbox_taxonomy::channel::*;
 use foxbox_taxonomy::services::{ AdapterId, Id, Service, ServiceId };
 use foxbox_taxonomy::util::Maybe;
-use foxbox_taxonomy::values::{ Type, Value };
+use foxbox_taxonomy::values::{ format, Value };
 use std::collections::HashMap;
 use std::sync::Arc;
 
@@ -89,7 +89,7 @@ pub fn init(adapt: &Arc<AdapterManager>) -> Result<(), Error> {
     try!(adapt.add_service(Service::empty(&service_id, &adapter_id)));
     try!(adapt.add_channel(Channel {
         feature: Id::new("speak/sentence"),
-        supports_send: Some(Signature::accepts(Maybe::Required(Type::String))),
+        supports_send: Some(Signature::accepts(Maybe::Required(format::STRING.clone()))),
         id: talk_setter_id,
         service: service_id,
         adapter: adapter_id,

--- a/src/main.rs
+++ b/src/main.rs
@@ -41,6 +41,8 @@ extern crate iron;
 extern crate iron_cors;
 #[cfg(test)]
 extern crate iron_test;
+#[macro_use]
+extern crate lazy_static;
 extern crate libc;
 #[macro_use]
 extern crate log;


### PR DESCRIPTION
6th big Decentralization PR. This one gets us rid of enum `Type` and replaces it with a trait `Format`.
I hope that the 7th will be the final PR.
