### PR TITLE
Followup to https://github.com/fxbox/foxbox/pull/486

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -693,14 +693,14 @@ version = "0.1.0"
 dependencies = [
  "foxbox_taxonomy 0.1.2",
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "openzwave-stateful 0.1.0 (git+https://github.com/dhylands/openzwave-stateful-rust?rev=43c11d96a019dd58723f76d0e84061971ef07b20)",
+ "openzwave-stateful 0.1.0 (git+https://github.com/fxbox/openzwave-stateful-rust)",
  "transformable_channels 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "openzwave-stateful"
 version = "0.1.0"
-source = "git+https://github.com/dhylands/openzwave-stateful-rust?rev=43c11d96a019dd58723f76d0e84061971ef07b20#43c11d96a019dd58723f76d0e84061971ef07b20"
+source = "git+https://github.com/fxbox/openzwave-stateful-rust#481baff1d7671dd44df00a00b9c008550407aecb"
 dependencies = [
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "openzwave 0.1.0 (git+https://github.com/fxbox/openzwave-rust)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ docopt = "0.6.78"
 docopt_macros = "0.6.80"
 env_logger = "0.3.2"
 #get_if_addrs = "0.3.1"
-get_if_addrs = { git = "https://github.com/dhylands/get_if_addrs", rev = "23632fd3473d42d3dc5710fc7855c5979b10ce50" }
+get_if_addrs = { git = "https://github.com/dhylands/get_if_addrs", rev = "23632fd3473d42d3dc5710fc7855c5979b10ce50" } # Temporary until get_if_addrs PR to update to libc 0.2 is merged
 hyper = "0.8.1"
 libc = "0.2.7"
 log = "0.3"

--- a/components/openzwave-adapter/Cargo.toml
+++ b/components/openzwave-adapter/Cargo.toml
@@ -4,8 +4,7 @@ version = "0.1.0"
 authors = ["Julien Wajsberg <felash@gmail.com>"]
 
 [dependencies]
-#openzwave-stateful = { git = "https://github.com/fxbox/openzwave-stateful-rust" }
-openzwave-stateful = { git = "https://github.com/dhylands/openzwave-stateful-rust", rev = "43c11d96a019dd58723f76d0e84061971ef07b20" }
+openzwave-stateful = { git = "https://github.com/fxbox/openzwave-stateful-rust" }
 foxbox_taxonomy = { path = "../taxonomy/" }
 transformable_channels = "^0.1"
 log = "^0.3"


### PR DESCRIPTION
Now that https://github.com/fxbox/openzwave-stateful-rust/pull/19 has landed
we can point back to the fxbox openzwave-stateful-rust repo
