### PR TITLE
Decentralizing: Removing big centralized Value

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8,7 +8,7 @@ dependencies = [
  "docopt_macros 0.6.84 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "foxbox_core 0.1.0",
- "foxbox_taxonomy 0.1.2",
+ "foxbox_taxonomy 0.2.0",
  "foxbox_thinkerbell 0.1.2",
  "foxbox_users 0.1.0 (git+https://github.com/fxbox/users.git?rev=d4e5277)",
  "get_if_addrs 0.4.0 (git+https://github.com/dhylands/get_if_addrs?rev=23632fd3473d42d3dc5710fc7855c5979b10ce50)",
@@ -34,9 +34,9 @@ dependencies = [
  "rust-crypto 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc_version 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 0.7.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_macros 0.7.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_macros 0.7.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "stainless 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "staticfile 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempdir 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -61,7 +61,7 @@ dependencies = [
 [[package]]
 name = "IOKit-sys"
 version = "0.1.4"
-source = "git+https://github.com/dhylands/iokit-sys?rev=256dadec3b63ecd85467ada1d4ada8e90ac9ce53#256dadec3b63ecd85467ada1d4ada8e90ac9ce53"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "CoreFoundation-sys 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -104,13 +104,13 @@ dependencies = [
  "iron 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "persistent 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "plugin 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 0.7.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "byteorder"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -245,18 +245,19 @@ dependencies = [
 
 [[package]]
 name = "foxbox_taxonomy"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "chrono 0.2.22 (registry+https://github.com/rust-lang/crates.io-index)",
  "clippy 0.0.71 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mopa 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "odds 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "rusqlite 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 0.7.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_macros 0.7.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_macros 0.7.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "string_cache 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "sublock 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "transformable_channels 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -267,12 +268,12 @@ name = "foxbox_thinkerbell"
 version = "0.1.2"
 dependencies = [
  "chrono 0.2.22 (registry+https://github.com/rust-lang/crates.io-index)",
- "foxbox_taxonomy 0.1.2",
+ "foxbox_taxonomy 0.2.0",
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "rusqlite 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 0.7.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_macros 0.7.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_macros 0.7.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "transformable_channels 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -545,6 +546,11 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "mopa"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "mount"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -692,7 +698,7 @@ dependencies = [
 name = "openzwave-adapter"
 version = "0.1.0"
 dependencies = [
- "foxbox_taxonomy 0.1.2",
+ "foxbox_taxonomy 0.2.0",
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "openzwave-stateful 0.1.0 (git+https://github.com/fxbox/openzwave-stateful-rust)",
  "transformable_channels 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -891,12 +897,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "serde"
-version = "0.7.6"
+version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "serde_codegen"
-version = "0.7.6"
+version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "aster 0.17.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -910,24 +916,24 @@ version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "num-traits 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 0.7.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "serde_macros"
-version = "0.7.5"
+version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "serde_codegen 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_codegen 0.7.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "serial_ports"
 version = "0.1.1"
-source = "git+https://github.com/dhylands/serial-ports-rs#a0764af29a33b5ad828d93ab9a104ac8453adfd1"
+source = "git+https://github.com/dhylands/serial-ports-rs#e128a59af383d29e4aec6f111f22f5a20dbe6316"
 dependencies = [
  "CoreFoundation-sys 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "IOKit-sys 0.1.4 (git+https://github.com/dhylands/iokit-sys?rev=256dadec3b63ecd85467ada1d4ada8e90ac9ce53)",
+ "IOKit-sys 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "cfg-if 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -939,7 +945,7 @@ name = "sha1"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "byteorder 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byteorder 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -982,7 +988,7 @@ dependencies = [
  "lazy_static 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "phf_generator 0.7.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "phf_shared 0.7.15 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 0.7.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1049,9 +1055,9 @@ dependencies = [
  "mktemp 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "openssl 0.7.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "openssl-sys 0.7.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 0.7.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_macros 0.7.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_macros 0.7.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/components/openzwave-adapter/src/lib.rs
+++ b/components/openzwave-adapter/src/lib.rs
@@ -148,7 +148,7 @@ fn ozw_vid_as_taxo_value(vid: &ValueID) -> Option<Value> {
                 if ref_eq(kind, &DOOR_IS_OPEN) {
                     Some(Value::new(if value {OpenClosed::Open} else {OpenClosed::Closed}))
                 } else if ref_eq(kind, &DOOR_IS_LOCKED) {
-                    Some(Value::new(if value {DoorLocked::Locked} else {DoorLocked::Unlocked}))
+                    Some(Value::new(if value {IsLocked::Locked} else {IsLocked::Unlocked}))
                 } else {
                     None
                 }
@@ -170,8 +170,8 @@ fn set_ozw_vid_from_taxo_value(vid: &ValueID, value: Value) -> Result<(), TaxoEr
         ValueType::ValueType_Bool => {
             if let Some(open_closed) = value.downcast::<OpenClosed>() {
                 vid.set_bool(*open_closed == OpenClosed::Open)
-            } else if let Some(locked_unlocked) = value.downcast::<DoorLocked>() {
-                vid.set_bool(*locked_unlocked == DoorLocked::Locked)
+            } else if let Some(locked_unlocked) = value.downcast::<IsLocked>() {
+                vid.set_bool(*locked_unlocked == IsLocked::Locked)
             } else {
                 return Err(TaxoError::InvalidValue) // TODO InvalidType would be better but we'll need to fix specific types for specific TaxoIds
             }

--- a/components/openzwave-adapter/src/lib.rs
+++ b/components/openzwave-adapter/src/lib.rs
@@ -107,18 +107,18 @@ trait RangeChecker {
     fn should_send(&self, &Value, EventType) -> bool;
 }
 
-impl RangeChecker for Option<Box<Range>> {
+impl RangeChecker for Option<Value> {
     fn should_send(&self, value: &Value, event_type: EventType) -> bool {
         match *self {
             None => event_type == EventType::Enter, // no range means we send only Enter events
-            Some(ref range) => range.contains(value)
+            Some(ref range) => range == value // FIXME: This won't scale up to interesting ranges.
         }
     }
 }
 
-impl RangeChecker for Range {
+impl RangeChecker for Value {
     fn should_send(&self, value: &Value, _: EventType) -> bool {
-        self.contains(value)
+        self == value // FIXME: This won't scale up to interesting ranges.
     }
 }
 
@@ -146,9 +146,9 @@ fn ozw_vid_as_taxo_value(vid: &ValueID) -> Option<Value> {
                     return None;
                 };
                 if ref_eq(kind, &DOOR_IS_OPEN) {
-                    Some(Value::OpenClosed(if value {OpenClosed::Open} else {OpenClosed::Closed}))
+                    Some(Value::new(if value {OpenClosed::Open} else {OpenClosed::Closed}))
                 } else if ref_eq(kind, &DOOR_IS_LOCKED) {
-                    Some(Value::DoorLocked(if value {DoorLocked::Locked} else {DoorLocked::Unlocked}))
+                    Some(Value::new(if value {DoorLocked::Locked} else {DoorLocked::Unlocked}))
                 } else {
                     None
                 }
@@ -168,11 +168,12 @@ fn set_ozw_vid_from_taxo_value(vid: &ValueID, value: Value) -> Result<(), TaxoEr
 
     let result = match vid.get_type() {
         ValueType::ValueType_Bool => {
-            match value {
-                //Value::OnOff(onOff) => { vid.set_bool(onOff == OnOff::On) } // TODO support switches
-                Value::OpenClosed(open_closed) => { vid.set_bool(open_closed == OpenClosed::Open) }
-                Value::DoorLocked(locked_unlocked) => { vid.set_bool(locked_unlocked == DoorLocked::Locked) }
-                _ => { return Err(TaxoError::InvalidValue) } // TODO InvalidType would be better but we'll need to fix specific types for specific TaxoIds
+            if let Some(open_closed) = value.downcast::<OpenClosed>() {
+                vid.set_bool(*open_closed == OpenClosed::Open)
+            } else if let Some(locked_unlocked) = value.downcast::<DoorLocked>() {
+                vid.set_bool(*locked_unlocked == DoorLocked::Locked)
+            } else {
+                return Err(TaxoError::InvalidValue) // TODO InvalidType would be better but we'll need to fix specific types for specific TaxoIds
             }
         }
         _ => { return Err(TaxoError::InternalError(InternalError::GenericError(format!("Unsupported OZW type: {:?}", vid.get_type())))) }
@@ -182,18 +183,14 @@ fn set_ozw_vid_from_taxo_value(vid: &ValueID, value: Value) -> Result<(), TaxoEr
 }
 
 fn start_including(ozw: &ZWaveManager, home_id: u32, value: &Value) -> Result<(), TaxoError> {
-    match *value {
-        Value::IsSecure(ref is_secure) => {
-            let is_secure_bool = *is_secure == IsSecure::Secure;
-            try!(
-                ozw.add_node(home_id, is_secure_bool)
-                    .map_err(|e| TaxoError::InternalError(InternalError::GenericError(format!("Error while including node on network {}: {}", home_id, e))))
-            );
-            info!("[OpenZWaveAdapter] Controller on network {} is awaiting an include in {} mode, please do the appropriate steps to include a device.", home_id, is_secure);
-            Ok(())
-        }
-        _ => Err(TaxoError::TypeError(TypeError::new(&format::IS_SECURE, &value)))
-    }
+    let is_secure = try!(value.cast::<IsSecure>());
+    let is_secure_bool = *is_secure == IsSecure::Secure;
+    try!(
+        ozw.add_node(home_id, is_secure_bool)
+            .map_err(|e| TaxoError::InternalError(InternalError::GenericError(format!("Error while including node on network {}: {}", home_id, e))))
+    );
+    info!("[OpenZWaveAdapter] Controller on network {} is awaiting an include in {} mode, please do the appropriate steps to include a device.", home_id, is_secure);
+    Ok(())
 }
 
 fn start_excluding(ozw: &ZWaveManager, home_id: u32) -> Result<(), TaxoError> {
@@ -453,13 +450,13 @@ impl OpenzwaveAdapter {
                             previous
                         };
 
-                        for &(ref range, ref sender) in &watchers {
-                            debug!("[OpenzwaveAdapter::ValueChanged] Iterating over watcher {:?} {:?}", taxo_id, range);
+                        for &(ref when, ref sender) in &watchers {
+                            debug!("[OpenzwaveAdapter::ValueChanged] Iterating over watcher {:?} {:?}", taxo_id, when);
 
-                            let should_send_value = range.should_send(&taxo_value, EventType::Enter);
+                            let should_send_value = when.should_send(&taxo_value, EventType::Enter);
 
                             if let Some(ref previous_value) = previous_value {
-                                let should_send_previous = range.should_send(previous_value, EventType::Exit);
+                                let should_send_previous = when.should_send(previous_value, EventType::Exit);
                                 // If the new and the old values are both in the same range, we
                                 // need to send nothing.
                                 if should_send_value && should_send_previous { continue }
@@ -564,15 +561,6 @@ impl taxonomy::adapter::Adapter for OpenzwaveAdapter {
 
             let sender = Arc::new(Mutex::new(sender)); // Mutex is necessary because cb is not Sync.
             debug!("[OpenzwaveAdapter::register_watch] Should register a watcher for {:?} {:?}", id, range);
-            let range = match range {
-                None => None,
-                Some(Value::Range(range)) => Some(range),
-                Some(_) => {
-                    // Ignore.
-                    // FIXME: Log?
-                    return None
-                }
-            };
             let watch_guard = {
                 let mut watchers = self.watchers.lock().unwrap();
                 watchers.push(id.clone(), range.clone(), sender.clone())

--- a/components/openzwave-adapter/src/watchers.rs
+++ b/components/openzwave-adapter/src/watchers.rs
@@ -10,8 +10,8 @@ use std::sync::{ Arc, Mutex, Weak };
 
 pub type SyncSender = Mutex<Box<ExtSender<WatchEvent<Value>>>>;
 type WatchersMap = HashMap<usize, Arc<SyncSender>>;
-type RangedWeakSender = (Option<Box<Range>>, Weak<SyncSender>);
-pub type RangedSyncSender = (Option<Box<Range>>, Arc<SyncSender>);
+type RangedWeakSender = (Option<Value>, Weak<SyncSender>);
+pub type RangedSyncSender = (Option<Value>, Arc<SyncSender>);
 
 pub struct Watchers {
     current_index: usize,
@@ -28,7 +28,7 @@ impl Watchers {
         }
     }
 
-    pub fn push(&mut self, taxo_id: TaxoId<Channel>, range: Option<Box<Range>>, watcher: Arc<SyncSender>) -> WatcherGuard {
+    pub fn push(&mut self, taxo_id: TaxoId<Channel>, range: Option<Value>, watcher: Arc<SyncSender>) -> WatcherGuard {
         let index = self.current_index;
         self.current_index += 1;
         {

--- a/components/taxonomy/Cargo.toml
+++ b/components/taxonomy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "foxbox_taxonomy"
-version = "0.1.2"
+version = "0.2.0"
 authors = ["David Rajchenbach-Teller <dteller@mozilla.com>"]
 
 [dependencies]
@@ -9,6 +9,7 @@ clippy = "0.0.71"
 lazy_static = "^0.1"
 libc = "0.2.9"
 log = "0.3"
+mopa = "0.2.2"
 odds = "0.2.*"
 rusqlite = "0.6.0"
 serde = "0.7.0"

--- a/components/taxonomy/src/adapter.rs
+++ b/components/taxonomy/src/adapter.rs
@@ -115,6 +115,7 @@ pub trait RawAdapter: Send + Sync {
     /// reboots/reconnections.
     fn id(&self) -> Id<AdapterId>;
 
+    #[allow(type_complexity)] // Making the type simpler doesn't make sense, as it wouldn't match the other signatures in this module.
     fn fetch_values(&self, mut target: Vec<(Id<Channel>, Arc<Format>)>, _: User) -> ResultMap<Id<Channel>, Option<(Payload, Arc<Format>)>, Error> {
         target.drain(..).map(|(id, _)| {
             (id.clone(), Err(Error::OperationNotSupported(Operation::Watch, id)))

--- a/components/taxonomy/src/channel.rs
+++ b/components/taxonomy/src/channel.rs
@@ -181,11 +181,11 @@ lazy_static! {
     /// - watch this channel to be informed when it is (un)locked.
     pub static ref DOOR_IS_LOCKED : Channel = Channel {
         feature: Id::new("door/is-locked"),
-        supports_send: Some(Signature::accepts(Maybe::Required(format::OPEN_CLOSED.clone()))),
-        supports_fetch: Some(Signature::returns(Maybe::Required(format::OPEN_CLOSED.clone()))),
+        supports_send: Some(Signature::accepts(Maybe::Required(format::IS_LOCKED.clone()))),
+        supports_fetch: Some(Signature::returns(Maybe::Required(format::IS_LOCKED.clone()))),
         supports_watch: Some(Signature {
-            accepts: Maybe::Optional(format::OPEN_CLOSED.clone()),
-            returns: Maybe::Required(format::OPEN_CLOSED.clone())
+            accepts: Maybe::Optional(format::IS_LOCKED.clone()),
+            returns: Maybe::Required(format::IS_LOCKED.clone())
         }),
         .. Channel::default()
     };

--- a/components/taxonomy/src/channel.rs
+++ b/components/taxonomy/src/channel.rs
@@ -183,7 +183,10 @@ lazy_static! {
         feature: Id::new("door/is-locked"),
         supports_send: Some(Signature::accepts(Maybe::Required(format::OPEN_CLOSED.clone()))),
         supports_fetch: Some(Signature::returns(Maybe::Required(format::OPEN_CLOSED.clone()))),
-        supports_watch: Some(Signature::returns(Maybe::Required(format::OPEN_CLOSED.clone()))),
+        supports_watch: Some(Signature {
+            accepts: Maybe::Optional(format::OPEN_CLOSED.clone()),
+            returns: Maybe::Required(format::OPEN_CLOSED.clone())
+        }),
         .. Channel::default()
     };
 
@@ -197,7 +200,10 @@ lazy_static! {
         feature: Id::new("door/is-open"),
         supports_send: Some(Signature::accepts(Maybe::Required(format::OPEN_CLOSED.clone()))),
         supports_fetch: Some(Signature::returns(Maybe::Required(format::OPEN_CLOSED.clone()))),
-        supports_watch: Some(Signature::returns(Maybe::Required(format::OPEN_CLOSED.clone()))),
+        supports_watch: Some(Signature {
+            accepts: Maybe::Optional(format::OPEN_CLOSED.clone()),
+            returns: Maybe::Required(format::OPEN_CLOSED.clone())
+        }),
         .. Channel::default()
     };
 
@@ -211,7 +217,10 @@ lazy_static! {
         feature: Id::new("light/is-on"),
         supports_send: Some(Signature::accepts(Maybe::Required(format::ON_OFF.clone()))),
         supports_fetch: Some(Signature::returns(Maybe::Required(format::ON_OFF.clone()))),
-        supports_watch: Some(Signature::returns(Maybe::Required(format::ON_OFF.clone()))),
+        supports_watch: Some(Signature {
+            accepts: Maybe::Optional(format::ON_OFF.clone()),
+            returns: Maybe::Required(format::ON_OFF.clone())
+        }),
         .. Channel::default()
     };
 

--- a/components/taxonomy/src/io.rs
+++ b/components/taxonomy/src/io.rs
@@ -1,6 +1,8 @@
 //! Representation of data.
 //!
 //! Instances of `Payload` are typically combinations of JSON and binary components.
+#![allow(identity_op)] // FIXME: Remove this once Clippy accepts Serialize
+
 use api::Error;
 use parse::*;
 use values::*;
@@ -16,7 +18,7 @@ pub struct BinarySource;
 pub struct BinaryTarget;
 
 /// Placeholder.
-#[derive(Clone, Debug, Serialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
 pub struct SerializeError;
 impl fmt::Display for SerializeError {
     fn fmt(&self, formatter: &mut fmt::Formatter) -> Result<(), fmt::Error> {
@@ -29,26 +31,11 @@ impl StdError for SerializeError {
         ""
     }
 }
-
-pub trait Format: Send + Sync + 'static {
-    fn description(&self) -> String;
-    fn parse(&self, source: &JSON, _binary: &BinarySource) -> Result<Value, ParseError> {
-        // Placeholder implementation
-        Value::parse(Path::new(), source)
-    }
-    fn serialize(&self, source: &Value, _binary: &BinaryTarget) -> Result<JSON, SerializeError> {
-        // Placeholder implementation
-        Ok(source.to_json())
-    }
-
-}
-
-impl fmt::Debug for Format {
-    fn fmt(&self, fmt: &mut fmt::Formatter) -> Result<(), fmt::Error> {
-        fmt.write_str(&self.description())
+impl From<SerializeError> for Error {
+    fn from(v: SerializeError) -> Error {
+        Error::SerializeError(v)
     }
 }
-
 
 #[derive(Clone, Serialize, Deserialize, Debug, PartialEq)]
 pub struct Payload {
@@ -56,33 +43,25 @@ pub struct Payload {
 }
 
 impl Payload {
-    /// Serialize a `Value` into a `Payload`.
-    /// Note that this is a placeholder method. It will disappear very soon.
-    #[deprecated]
-    pub fn from_value_auto(value: &Value) -> Payload {
+    fn new(json: JSON) -> Self {
         Payload {
-            json: value.to_json()
+            json: json
         }
     }
-
     pub fn empty() -> Self {
-        Payload {
-            json: JSON::Null
-        }
+        Self::new(JSON::Null)
     }
 
     /// Serialize a `Value` into a `Payload`.
     pub fn from_value(value: &Value, format: &Arc<Format>) -> Result<Payload, Error> {
-        match format.serialize(value, &BinaryTarget) {
-            Ok(json) => Ok(Payload {
-                json: json
-            }),
-            Err(err) => Err(Error::SerializeError(err))
-        }
+        format.serialize(value, &BinaryTarget)
+            .map(Self::new)
+    }
+    pub fn from_data<T>(data: T, format: &Arc<Format>) -> Result<Payload, Error> where T: Data + PartialEq {
+        Self::from_value(&Value::new(data), format)
     }
     pub fn to_value(&self, format: &Arc<Format>) -> Result<Value, Error> {
-        format.parse(&self.json, &BinarySource)
-            .map_err(Error::ParseError)
+        format.parse(Path::new(), &self.json, &BinarySource)
     }
 }
 
@@ -109,3 +88,50 @@ impl Parser<Payload> for Payload {
     }
 }
 
+pub struct Format {
+    description: Box<Fn() -> String + Send + Sync>,
+    #[allow(type_complexity)] // This type is used exactly once in the code.
+    parse: Box<Fn(Path, &JSON, &BinarySource) -> Result<Value, Error> + Send + Sync>,
+    serialize: Box<Fn(&Value, &BinaryTarget) -> Result<JSON, Error> + Send + Sync>
+}
+impl Format {
+    #[allow(new_without_default)] // Clippy's warning doesn't make sense.
+    pub fn new<T>() -> Self where T: Data + PartialEq {
+        let description = || T::description();
+        Format {
+            description: Box::new(description),
+            parse: Box::new(|path, source, binary| {
+                T::parse(path, source, binary)
+                    .map(Value::new)
+            }),
+            serialize: Box::new(|value, target| {
+                let value : &Value = value;
+                let data = try!(value.cast::<T>());
+                T::serialize(data, target)
+            }),
+        }
+    }
+
+    /// A human-readable description of the _type_ of the value.
+    ///
+    /// Used mainly in `TypeError` error messages.
+    pub fn description(&self) -> String {
+        (self.description)()
+    }
+
+    /// Attempt to build a `Value` from a json `source` and `binary` components.
+    pub fn parse(&self, path: Path, source: &JSON, binary: &BinarySource) -> Result<Value, Error> {
+        (self.parse)(path, source, binary)
+    }
+
+    /// Serialize a `Value` into a `JSON`, storing binary data in `binary`.
+    pub fn serialize(&self, source: &Value, binary: &BinaryTarget) -> Result<JSON, Error> {
+        (self.serialize)(source, binary)
+    }
+}
+
+impl fmt::Debug for Format {
+    fn fmt(&self, formatter: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        self.description().fmt(formatter)
+    }
+}

--- a/components/taxonomy/src/lib.rs
+++ b/components/taxonomy/src/lib.rs
@@ -4,6 +4,7 @@
 #![plugin(clippy)]
 // To prevent clippy being noisy with derive(...)
 #![allow(used_underscore_binding)]
+#![allow(let_unit_value)] // For some reason, clippy decides to display this warning, without any hint as to *where* it applies.
 
 #[macro_use]
 extern crate lazy_static;
@@ -12,6 +13,8 @@ extern crate chrono;
 extern crate libc;
 #[macro_use]
 extern crate log;
+#[macro_use]
+extern crate mopa;
 extern crate odds;
 extern crate rusqlite;
 extern crate serde;

--- a/components/taxonomy/src/manager.rs
+++ b/components/taxonomy/src/manager.rs
@@ -288,7 +288,7 @@ impl API for AdapterManager {
     }
 
     /// Watch for any change
-    fn watch_values(&self, watch: TargetMap<ChannelSelector, Exactly<(Payload, Arc<Format>)>>,
+    fn watch_values(&self, watch: TargetMap<ChannelSelector, Exactly<Payload>>,
         on_event: Box<ExtSender<api::WatchEvent>>) -> Self::WatchGuard
     {
         let (request, watch_key, is_dropped) =

--- a/components/taxonomy/src/values.rs
+++ b/components/taxonomy/src/values.rs
@@ -419,7 +419,7 @@ impl Data for OpenClosed {
 ///
 /// Values of this type are represented by strings "Locked" | "Unlocked".
 #[derive(Debug, Clone, Eq, PartialEq)]
-pub enum DoorLocked {
+pub enum IsLocked {
     /// # JSON
     ///
     /// Represented by "Locked".
@@ -428,10 +428,10 @@ pub enum DoorLocked {
     /// use foxbox_taxonomy::values::*;
     /// use foxbox_taxonomy::parse::*;
     ///
-    /// let parsed = DoorLocked::from_str("\"Locked\"").unwrap();
-    /// assert_eq!(parsed, DoorLocked::Locked);
+    /// let parsed = IsLocked::from_str("\"Locked\"").unwrap();
+    /// assert_eq!(parsed, IsLocked::Locked);
     ///
-    /// let serialized: JSON = DoorLocked::Locked.to_json();
+    /// let serialized: JSON = IsLocked::Locked.to_json();
     /// assert_eq!(serialized.as_string().unwrap(), "Locked");
     /// ```
     Locked,
@@ -444,61 +444,61 @@ pub enum DoorLocked {
     /// use foxbox_taxonomy::values::*;
     /// use foxbox_taxonomy::parse::*;
     ///
-    /// let parsed = DoorLocked::from_str("\"Unlocked\"").unwrap();
-    /// assert_eq!(parsed, DoorLocked::Unlocked);
+    /// let parsed = IsLocked::from_str("\"Unlocked\"").unwrap();
+    /// assert_eq!(parsed, IsLocked::Unlocked);
     ///
-    /// let serialized: JSON = DoorLocked::Unlocked.to_json();
+    /// let serialized: JSON = IsLocked::Unlocked.to_json();
     /// assert_eq!(serialized.as_string().unwrap(), "Unlocked");
     /// ```
     Unlocked,
 }
 
-impl DoorLocked {
+impl IsLocked {
     fn as_bool(&self) -> bool {
         match *self {
-            DoorLocked::Locked => true,
-            DoorLocked::Unlocked => false,
+            IsLocked::Locked => true,
+            IsLocked::Unlocked => false,
         }
     }
 }
 
-impl Data for DoorLocked {
+impl Data for IsLocked {
     fn description() -> String {
-        "DoorLocked".to_owned()
+        "IsLocked".to_owned()
     }
     fn parse(path: Path, source: &JSON, _binary: &BinarySource) -> Result<Self, Error> {
         match source.as_string() {
-            Some("Locked") => Ok(DoorLocked::Locked),
-            Some("Unlocked") => Ok(DoorLocked::Unlocked),
+            Some("Locked") => Ok(IsLocked::Locked),
+            Some("Unlocked") => Ok(IsLocked::Unlocked),
             Some(str) => Err(Error::ParseError(ParseError::unknown_constant(str, &path))),
-            None => Err(Error::ParseError(ParseError::type_error("DoorLocked", &path, "string")))
+            None => Err(Error::ParseError(ParseError::type_error("IsLocked", &path, "string")))
         }
     }
     fn serialize(source: &Self, _binary: &BinaryTarget) -> Result<JSON, Error> {
         let str = match *source {
-            DoorLocked::Locked => "Locked",
-            DoorLocked::Unlocked => "Unlocked"
+            IsLocked::Locked => "Locked",
+            IsLocked::Unlocked => "Unlocked"
         };
         Ok(JSON::String(str.to_owned()))
     }
 }
 
-impl ToJSON for DoorLocked {
+impl ToJSON for IsLocked {
     fn to_json(&self) -> JSON {
         match *self {
-            DoorLocked::Locked => JSON::String("Locked".to_owned()),
-            DoorLocked::Unlocked => JSON::String("Unlocked".to_owned())
+            IsLocked::Locked => JSON::String("Locked".to_owned()),
+            IsLocked::Unlocked => JSON::String("Unlocked".to_owned())
         }
     }
 }
 
-impl PartialOrd for DoorLocked {
+impl PartialOrd for IsLocked {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
         Some(self.cmp(other))
     }
 }
 
-impl Ord for DoorLocked {
+impl Ord for IsLocked {
     fn cmp(&self, other: &Self) -> Ordering {
         self.as_bool().cmp(&other.as_bool())
     }
@@ -1189,6 +1189,7 @@ pub mod format {
         pub static ref ON_OFF : Arc<Format> = Arc::new(Format::new::<OnOff>());
         pub static ref OPEN_CLOSED : Arc<Format> = Arc::new(Format::new::<OpenClosed>());
         pub static ref IS_SECURE : Arc<Format> = Arc::new(Format::new::<IsSecure>());
+        pub static ref IS_LOCKED : Arc<Format> = Arc::new(Format::new::<IsLocked>());
         pub static ref COLOR : Arc<Format> = Arc::new(Format::new::<Color>());
         pub static ref JSON: Arc<Format> = Arc::new(Format::new::<Json>());
         pub static ref STRING : Arc<Format> = Arc::new(Format::new::<String>());

--- a/components/thinkerbell/examples/ruleset.json
+++ b/components/thinkerbell/examples/ruleset.json
@@ -10,10 +10,8 @@
             }
           ],
           "feature": "clock/time-of-day-s",
-          "range": {
-            "Geq": {
-              "Duration": 5
-            }
+          "when": {
+            "Duration": 5
           }
         },
         {
@@ -23,10 +21,8 @@
             }
           ],
           "feature": "clock/time-of-day-s",
-          "range": {
-            "Leq": {
+          "when": {
               "Duration": 2
-            }
           }
         }
       ],

--- a/components/thinkerbell/src/compile.rs
+++ b/components/thinkerbell/src/compile.rs
@@ -167,7 +167,7 @@ impl<Env> Compiler<Env> where Env: ExecutableDevEnv {
         Ok(Match {
             source: source,
             feature: match_.feature,
-            range: match_.range,
+            when: match_.when,
             duration: match_.duration,
             phantom: PhantomData
         })

--- a/src/adapters/console/mod.rs
+++ b/src/adapters/console/mod.rs
@@ -59,12 +59,13 @@ impl Adapter for Console {
             .map(|(id, value)| {
                 let result = {
                     if id == self.setter_stdout_id {
-                        if let Value::String(s) = value {
-                            info!("[console@link.mozilla.org] {} (user {:?})", s, user);
-                        } else {
-                            info!("[console@link.mozilla.org] {:?} (user {:?})", value, user);
+                        match value.cast::<String>() {
+                            Err(err) => Err(err),
+                            Ok(s) => {
+                                info!("[console@link.mozilla.org] {} (user {:?})", s, user);
+                                Ok(())
+                            }
                         }
-                        Ok(())
                     } else {
                         Err(Error::InternalError(InternalError::NoSuchChannel(id.clone())))
                     }

--- a/src/adapters/ip_camera/mod.rs
+++ b/src/adapters/ip_camera/mod.rs
@@ -17,7 +17,7 @@ use foxbox_taxonomy::api::{Error, InternalError, User};
 use foxbox_taxonomy::channel::*;
 use foxbox_taxonomy::manager::*;
 use foxbox_taxonomy::services::*;
-use foxbox_taxonomy::values::{ Binary, Json, TypeError, Value };
+use foxbox_taxonomy::values::{ Binary, Json, Value };
 use foxbox_taxonomy::values::format;
 use self::api::*;
 use self::upnp_listener::IpCameraUpnpListener;
@@ -206,23 +206,23 @@ impl Adapter for IPCameraAdapter {
 
             if id == camera.username_id {
                 let rsp = camera.get_username();
-                return (id, Ok(Some(Value::String(Arc::new(rsp)))));
+                return (id, Ok(Some(Value::new(rsp))));
             }
 
             if id == camera.password_id {
                 let rsp = camera.get_password();
-                return (id, Ok(Some(Value::String(Arc::new(rsp)))));
+                return (id, Ok(Some(Value::new(rsp))));
             }
 
             if id == camera.image_list_id {
                 let rsp = camera.get_image_list();
-                return (id, Ok(Some(Value::Json(Arc::new(Json(serde_json::to_value(&rsp)))))));
+                return (id, Ok(Some(Value::new(Json(serde_json::to_value(&rsp))))));
             }
 
             if id == camera.image_newest_id {
                 return match camera.get_newest_image() {
-                    Ok(rsp) => (id, Ok(Some(Value::Binary(Binary {
-                        data: Arc::new(rsp),
+                    Ok(rsp) => (id, Ok(Some(Value::new(Binary {
+                        data: rsp,
                         mimetype: Id::new("image/jpeg")
                     })))),
                     Err(err) => (id, Err(err))
@@ -241,25 +241,23 @@ impl Adapter for IPCameraAdapter {
             };
 
             if id == camera.username_id {
-                if let Value::String(ref username) = value {
-                    camera.set_username(username);
-                    return (id, Ok(()));
+                return match value.cast::<String>() {
+                    Ok(username) => {
+                        camera.set_username(username);
+                        (id, Ok(()))
+                    }
+                    Err(err) => (id, Err(err))
                 }
-                return (id, Err(Error::TypeError(TypeError {
-                                got: value.description(),
-                                expected: format::STRING.description()
-                            })))
             }
 
             if id == camera.password_id {
-                if let Value::String(ref password) = value {
-                    camera.set_password(password);
-                    return (id, Ok(()));
+                return match value.cast::<String>() {
+                    Ok(password) => {
+                        camera.set_password(password);
+                        (id, Ok(()))
+                    }
+                    Err(err) => (id, Err(err))
                 }
-                return (id, Err(Error::TypeError(TypeError {
-                                got: value.description(),
-                                expected: format::STRING.description()
-                            })))
             }
 
             if id == camera.snapshot_id {

--- a/src/adapters/ip_camera/upnp_listener.rs
+++ b/src/adapters/ip_camera/upnp_listener.rs
@@ -54,13 +54,12 @@ impl UpnpListener for IpCameraUpnpListener {
 
         let url = try_get!(service.description, "/root/device/presentationURL");
 
-        let mut udn = try_get!(service.description, "/root/device/UDN").clone();
         // The UDN is typically of the for uuid:SOME-UID-HERE, but some devices
         // response with just a UUID. We strip off the uuid: prefix, if it exists
         // and use the resulting UUID as the service id.
-        if udn.starts_with("uuid:") {
-            udn = String::from(&udn[5..]);
-        }
+        let udn = try_get!(service.description, "/root/device/UDN")
+            .trim_left_matches("uuid:")
+            .to_owned();
 
         // TODO: We really need to update the IP/camera name in the event that
         //       it changed. I'll add this once we start persisting the camera

--- a/src/adapters/tts/mod.rs
+++ b/src/adapters/tts/mod.rs
@@ -62,9 +62,14 @@ impl<T: TtsEngine> Adapter for TtsAdapter<T> {
 
         values.drain().map(|(id, value)| {
             if id == self.talk_setter_id {
-                if let Value::String(text) = value {
-                    self.engine.say(text.deref());
-                    return (id, Ok(()));
+                match value.cast::<String>() {
+                    Ok(text) => {
+                        self.engine.say(text.deref());
+                        return (id, Ok(()));
+                    }
+                    Err(err) => {
+                        return (id, Err(err))
+                    }
                 }
             }
             (id.clone(), Err(Error::InternalError(InternalError::NoSuchChannel(id))))

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,7 +13,7 @@
 
 #![deny(clippy)]
 // TODO: re-enable deny mode once the identity_op issue is fixed.
-#![warn(identity_op)]
+#![allow(identity_op)]
 // Clippy tries hard to be clever but sometimes fails.
 #![warn(useless_let_if_seq)]
 // Needed for many #[derive(...)] macros

--- a/test/integration/test/ip_camera_test.js
+++ b/test/integration/test/ip_camera_test.js
@@ -32,7 +32,7 @@ Prepper.makeSuite('Control camera locally',function(){
   it('take a picture (using the channel id)',function(){
     var setter = 'channel:' +
       cameraService.id.replace('service:','snapshot.');
-    var payload = {'select': {'id': setter}, 'value': {'Unit': {}}};
+    var payload = {'select': {'id': setter}, 'value': null};
     return chakram.put(Prepper.foxboxManager.setterURL, payload)
     .then(function(cmdResponse) {
       expect(cmdResponse).to.have.status(200);
@@ -50,7 +50,7 @@ Prepper.makeSuite('Control camera locally',function(){
     var payload = {'id': getter};
     return chakram.put(Prepper.foxboxManager.getterURL, payload)
     .then(function(cmdResponse) {
-      var imageList = cmdResponse.body[getter].Json;
+      var imageList = cmdResponse.body[getter];
       var res = imageList[imageList.length - 1].match(datePrefix);
       expect(cmdResponse).to.have.status(200);
       expect(imageList.length).above(0);
@@ -75,7 +75,7 @@ Prepper.makeSuite('Control camera locally',function(){
     var setter = 'channel:' +
       cameraService.id.replace('service:','snapshot.');
     var payload = {'select': {'feature': 'camera/store-snapshot'}, 
-      'value': {'Unit': {}}};
+      'value': null};
     return chakram.put(Prepper.foxboxManager.setterURL, payload)
     .then(function(cmdResponse) {
       expect(cmdResponse).to.have.status(200);
@@ -90,10 +90,10 @@ Prepper.makeSuite('Control camera locally',function(){
     var getter = 'channel:'+
       cameraService.id.replace('service:','image_list.');
     var payload = {'feature': 'camera/x-image-list'};
-    
+
     return chakram.put(Prepper.foxboxManager.getterURL, payload)
     .then(function(cmdResponse) {
-      var imageList = cmdResponse.body[getter].Json;
+      var imageList = cmdResponse.body[getter];
       var res = imageList[imageList.length - 1].match(datePrefix);
       expect(cmdResponse).to.have.status(200);
       expect(imageList.length).above(0);

--- a/test/integration/test/philips_color_test.js
+++ b/test/integration/test/philips_color_test.js
@@ -48,7 +48,7 @@ Prepper.makeSuite('Control lights locally',function(){
 
       // send various values within valid range
       var payload = {'select': {'id': lights[testParam.lightID]}, 
-      'value': { 'Color': {'h':hue,'s':sat,'v':bri} } };
+      'value': { 'h':hue,'s':sat,'v':bri} };
 
       return chakram.put(Prepper.foxboxManager.setterURL,payload)
       .then(function(cmdResponse) {
@@ -71,7 +71,7 @@ Prepper.makeSuite('Control lights locally',function(){
 
     // send various values within valid range
     var payload = {'select': {'id': lights[0]},
-      'value': { 'Color': {'h':hue,'s':invalidSat,'v':bri} } };
+      'value': {'h':hue,'s':invalidSat,'v':bri} };
 
     return chakram.put(Prepper.foxboxManager.setterURL,payload)
     .then(function(cmdResponse) {
@@ -91,7 +91,7 @@ Prepper.makeSuite('Control lights locally',function(){
 
     // send various values within valid range
     var payload = {'select': {'id': lights[1]},
-      'value': { 'Color': {'h':hue,'s':sat,'v':invalidBri} } };
+      'value': {'h':hue,'s':sat,'v':invalidBri} };
 
     return chakram.put(Prepper.foxboxManager.setterURL,payload)
     .then(function(cmdResponse) {

--- a/test/integration/test/philips_light_test.js
+++ b/test/integration/test/philips_light_test.js
@@ -41,21 +41,21 @@ Prepper.makeSuite('Control lights locally',function(){
     // id and the philips hue id until the tag feature is implemented
     it('Turn on all lights one by one', function(){
       var lightID = lights[0];
-      var payload = {'select': {'id': lightID}, 'value': { 'OnOff': 'On' } };
+      var payload = {'select': {'id': lightID}, 'value': 'On' };
 
       return chakram.put(Prepper.foxboxManager.setterURL,payload)
       .then(function(cmdResponse) {
        expect(cmdResponse).to.have.status(200);
        expect(cmdResponse.body[lightID]).equals(null);
        lightID = lights[1];
-       payload = {'select': {'id': lightID}, 'value': { 'OnOff': 'On' } };
+       payload = {'select': {'id': lightID}, 'value': 'On' };
        return chakram.put(Prepper.foxboxManager.setterURL,payload);
      })
       .then(function(cmdResponse) {
         expect(cmdResponse).to.have.status(200);
         expect(cmdResponse.body[lightID]).equals(null);
         lightID = lights[2];
-        payload = {'select': {'id': lightID}, 'value': { 'OnOff': 'On' } };
+        payload = {'select': {'id': lightID}, 'value': 'On' };
         return chakram.put(Prepper.foxboxManager.setterURL,payload);
       })
       .then(function(cmdResponse) {
@@ -72,15 +72,15 @@ Prepper.makeSuite('Control lights locally',function(){
         expect(lights.length).equals(3);
 
         lights.forEach(light => {
-          expect(listResponse.body[light].OnOff).equals('On');
+          expect(listResponse.body[light]).equals('On');
         });
       }); 
     });
 
     it('Turn off all lights at once', function() {
 
-      var payload = {'select': {'feature': 'light/is-on'}, 
-        'value': {'OnOff':'Off'}};
+      var payload = {'select': {'feature': 'light/is-on'},
+        'value': 'Off'};
 
       return chakram.put(Prepper.foxboxManager.setterURL,payload)
       .then(function(cmdResponse) {
@@ -96,7 +96,7 @@ Prepper.makeSuite('Control lights locally',function(){
         expect(listResponse).to.have.status(200);
 
         lights.forEach(light => {
-          expect(listResponse.body[light].OnOff).equals('Off');
+          expect(listResponse.body[light]).equals('Off');
         });
       }); 
     });

--- a/test/integration/test/recipe_test.js
+++ b/test/integration/test/recipe_test.js
@@ -8,13 +8,13 @@ var source = {'name': 'Hellooo, Thinkerbell', 'rules':
             [{'source':
               [{'id':'OpenZWave72057594126794752 (Sensor)'}],
             'feature':'door/is-open',
-            'range':{'Eq':{'OpenClosed':'Open'}}
+            'when':{'Eq': 'Open'}
           }],
           'execute':
             [{'destination':
               [{'feature':'log/append-text'}],
               'feature':'log/append-text',
-              'value':{'String':'Closed'}}]}
+              'value': 'Closed'}]}
             ]};
 source = JSON.stringify(source);
 
@@ -24,10 +24,8 @@ function generateThinkerbellNewRecipePayload(recipeName) {
        'feature':'thinkerbell/add-rule'
     },
     'value':{
-       'ThinkerbellRule':{
-          'name': recipeName,
-          'source': source
-        }
+        'name': recipeName,
+        'source': source
     }
   };
 }

--- a/test/integration/test/webpush_test.js
+++ b/test/integration/test/webpush_test.js
@@ -13,25 +13,21 @@ Prepper.makeSuite('Test Push Service locally',function(){
        'id':'channel:subscription.webpush@link.mozilla.org'
      },
      'value': {
-       'Json': {
-         'subscriptions':[{
-           'push_uri': Prepper.webPush_server.getEndpointURI(),
-           'public_key': Prepper.webPush_server.getPublicKey()
-         }]
-      }
+       'subscriptions':[{
+         'push_uri': Prepper.webPush_server.getEndpointURI(),
+         'public_key': Prepper.webPush_server.getPublicKey()
+       }]
     }
   };
 
   var newWebPushSubscriptionPayload = 
   Object.assign({}, baseSubscriptionPayload, {
     value: {
-       Json: {
-          subscriptions: [{
-            'push_uri': Prepper.webPush_server.getEndpointURI(),
-            'public_key': Prepper.webPush_server.getPublicKey(),
-            'auth': Prepper.webPush_server.getUserAuth()
-          }]
-       }
+        subscriptions: [{
+          'push_uri': Prepper.webPush_server.getEndpointURI(),
+          'public_key': Prepper.webPush_server.getPublicKey(),
+          'auth': Prepper.webPush_server.getUserAuth()
+        }]
     }
   });
 
@@ -82,9 +78,9 @@ Prepper.makeSuite('Test Push Service locally',function(){
         })
         .then(function(cmdResp){
           expect(cmdResp).to.have.status(200);
-          expect(cmdResp.body[getter].Json.subscriptions[0].public_key)
+          expect(cmdResp.body[getter].subscriptions[0].public_key)
           .equals(Prepper.webPush_server.getPublicKey());
-          expect(cmdResp.body[getter].Json.subscriptions[0].push_uri)
+          expect(cmdResp.body[getter].subscriptions[0].push_uri)
           .equals(Prepper.webPush_server.getEndpointURI());
         });
       });
@@ -96,8 +92,7 @@ Prepper.makeSuite('Test Push Service locally',function(){
           'select': {
             'id': setter},
             'value': {
-              'Json': {
-                'resources':['livingroom', 'washroom']}}};
+                'resources':['livingroom', 'washroom']}};
         var getterPayload = {'id': getter};
 
         return chakram.put(Prepper.foxboxManager.setterURL,setterPayload)
@@ -109,9 +104,9 @@ Prepper.makeSuite('Test Push Service locally',function(){
         .then(function(cmdResp){
           expect(cmdResp).to.have.status(200);
           expect(cmdResp.body[getter]
-            .Json.resources[0]).equals('livingroom');
+            .resources[0]).equals('livingroom');
           expect(cmdResp.body[getter]
-            .Json.resources[1]).equals('washroom');
+            .resources[1]).equals('washroom');
         });
       });
 
@@ -124,8 +119,7 @@ Prepper.makeSuite('Test Push Service locally',function(){
             'id': setter
           },
           'value': {
-            'WebPushNotify': {
-              'resource':resource,'message':notificationText}}} ;
+              'resource':resource,'message':notificationText}} ;
         return chakram.put(Prepper.foxboxManager.setterURL, payload)
         .then(function(cmdResponse) {
           expect(cmdResponse).to.have.status(200);
@@ -144,8 +138,7 @@ Prepper.makeSuite('Test Push Service locally',function(){
               'id': setter
             },
             'value': {
-              'WebPushNotify': {
-                'resource':resource,'message':notificationText}}} ;
+                'resource':resource,'message':notificationText}} ;
           return chakram.put(Prepper.foxboxManager.setterURL, payload)
           .then(function(cmdResponse) {
           // collect the response from the webpush simulator 
@@ -169,11 +162,10 @@ Prepper.makeSuite('Test Push Service locally',function(){
               'id':setter
             }, 
             'value': {
-              'Json': {
                 'subscriptions':[{
                   'push_uri':pushURI,
                   'public_key':pushkey
-                }]}}};
+                }]}};
           var getterPayload = {'id': getter};
 
           return chakram.put(Prepper.foxboxManager.setterURL,setterPayload)
@@ -184,7 +176,7 @@ Prepper.makeSuite('Test Push Service locally',function(){
           })
           .then(function(cmdResp){
             expect(cmdResp).to.have.status(200);
-            expect(cmdResp.body[getter].Json.subscriptions.length).equals(0);
+            expect(cmdResp.body[getter].subscriptions.length).equals(0);
           });
         });
       });


### PR DESCRIPTION
This PR removes the big centralized enum `Value`, effectively ending all centralization in Taxonomy. The first two beneficiaries are Thinkerbell (which now defines its own value type `RuleSource`) and WebPush (which now defines its own value type `WebPushNotify`).
- [x] r? @fabricedesre for Foxbox.
- [x] r? @mcav for Thinkerbell.
- [x] r? @julienw for ZWave.
- [x] r? @cr for Philps Hue.
- [x] r? @dhylands for IP Camera.
- [x] r? @aosmond for WebPush.
- [x] r? @fabricedesre for TTS.
- [x] r? @npark-mozilla for integration tests.
- [x] f? @azasypkin for synchronization with front-end.

I still have a few PRs planned after this lands, but at this stage, Taxonomy will be Decentralized \o/
