### PR TITLE
Thinkerbell Adapter now expects rules as an object instead of a serialized string.

### DIFF
--- a/components/taxonomy/src/io.rs
+++ b/components/taxonomy/src/io.rs
@@ -17,9 +17,11 @@ pub struct BinarySource;
 /// Placeholder.
 pub struct BinaryTarget;
 
-/// Placeholder.
+
 #[derive(Clone, Debug, PartialEq, Eq, Serialize)]
-pub struct SerializeError;
+pub enum SerializeError {
+    JSON(String)
+}
 impl fmt::Display for SerializeError {
     fn fmt(&self, formatter: &mut fmt::Formatter) -> Result<(), fmt::Error> {
         (self as &fmt::Debug).fmt(formatter)

--- a/test/integration/test/recipe_test.js
+++ b/test/integration/test/recipe_test.js
@@ -16,17 +16,15 @@ var source = {'name': 'Hellooo, Thinkerbell', 'rules':
               'feature':'log/append-text',
               'value': 'Closed'}]}
             ]};
-source = JSON.stringify(source);
 
 function generateThinkerbellNewRecipePayload(recipeName) {
+  let copy = JSON.parse(JSON.stringify(source));
+  copy.name = recipeName;
   return {
     'select':{
        'feature':'thinkerbell/add-rule'
     },
-    'value':{
-        'name': recipeName,
-        'source': source
-    }
+    'value': copy
   };
 }
 


### PR DESCRIPTION
This should make things a bit more readable and a bit more robust.

In particular, this should fix 1) of https://github.com/fxbox/foxbox/pull/520#issuecomment-224869077 .
