### PR TITLE
Move rustc version check to a build script

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,27 +1,11 @@
-/* This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 use std::env;
 use std::fs;
 use std::path::Path;
 extern crate pkg_config;
-extern crate rustc_version;
-
-static RUSTC_DATE: &'static str = "2016-12-15";
-static RUSTC_HASH: &'static str = "8f02c429ad3e2ad687a222d1daae2e04bb9bb876";
-
-fn check_rustc_version() {
-    let info = rustc_version::version_meta();
-    let hash = info.commit_hash.unwrap_or("".to_owned());
-    let date = info.commit_date.unwrap_or("".to_owned());
-    if hash == RUSTC_HASH && date == RUSTC_DATE {
-        return;
-    }
-
-    panic!(r#"Found rustc ({} {}), but you need to install rustc nightly from {}, commit {}"#,
-           hash, date, RUSTC_DATE, RUSTC_HASH);
-}
 
 fn update_local_git_hook() {
     let p = env::current_dir().unwrap();
@@ -70,7 +54,6 @@ fn link_external_libs() {
 }
 
 fn main() {
-    check_rustc_version();
     update_local_git_hook();
     link_external_libs();
     copy_shared_static_files();

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+# Update this when doing a rustup.
+EXPECTED_HASH="8f02c429ad3e2ad687a222d1daae2e04bb9bb876"
+EXPECTED_DATE="2016-12-16"
+
+CURRENT_HASH=`rustc --version -v|grep commit-hash|cut -f 2 -d ' '`
+
+install_rustc() {
+    echo "Checking for rustup"
+    RUSTUP=`which rustup`
+    if [[ "$RUSTUP" == "" ]]; then
+        echo "Installing rustup"
+        curl https://sh.rustup.rs -sSf | sh
+        RUSTUP=`which rustup`
+    fi
+    $RUSTUP install nightly-$EXPECTED_DATE
+    $RUSTUP override set nightly-$EXPECTED_DATE
+}
+
+prompt_rust_install() {
+    while true; do
+        read -p "Do you wish to install the correct Rustc version? [y/n] " yn
+        case $yn in
+            [Yy]* ) install_rustc; break;;
+            [Nn]* ) exit;;
+            * ) echo "Please answer yes or no.";;
+        esac
+    done
+}
+
+if [ "$CURRENT_HASH" != "$EXPECTED_HASH" ]; then
+    echo "You need Rustc nightly from $EXPECTED_DATE to build."
+    echo "Found $CURRENT_HASH but expected $EXPECTED_HASH"
+    prompt_rust_install
+fi
+
+echo "Building..."
+set -e -x
+cargo build


### PR DESCRIPTION
That should make the nightly travis testing useful again.