### PR TITLE
File Storage Adapter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -211,10 +211,13 @@ dependencies = [
  "lazy_static 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memmap 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mime_guess 1.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "mio 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "mount 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "multicast_dns 0.2.0 (git+https://github.com/fxbox/multicast-dns.git?rev=91fe8d4)",
  "nix 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "notify 3.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "openssl 0.7.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "openssl-sys 0.7.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "openzwave-adapter 0.1.0",
@@ -240,6 +243,7 @@ dependencies = [
  "unicase 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "walkdir 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "ws 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -316,6 +320,16 @@ dependencies = [
  "unicase 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "urlencoded 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "fs2"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -566,11 +580,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "memmap"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "fs2 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "mime"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "mime_guess"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "mime 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "phf 0.7.20 (registry+https://github.com/rust-lang/crates.io-index)",
+ "phf_codegen 0.7.20 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicase 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -704,6 +740,24 @@ dependencies = [
  "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mio 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
+ "walkdir 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "notify"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bitflags 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "filetime 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fsevent 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fsevent-sys 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "inotify 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "mio 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
  "walkdir 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -864,6 +918,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "phf"
+version = "0.7.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "phf_shared 0.7.20 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "phf_codegen"
+version = "0.7.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "phf_generator 0.7.20 (registry+https://github.com/rust-lang/crates.io-index)",
+ "phf_shared 0.7.20 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "phf_generator"
 version = "0.7.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -876,6 +947,9 @@ dependencies = [
 name = "phf_shared"
 version = "0.7.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "unicase 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "pkg-config"
@@ -1334,6 +1408,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "walkdir"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "winapi"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1398,6 +1481,7 @@ dependencies = [
 "checksum error 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "a6e606f14042bb87cc02ef6a14db6c90ab92ed6f62d87e69377bc759fd7987cc"
 "checksum filetime 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "5363ab8e4139b8568a6237db5248646e5a8a2f89bd5ccb02092182b11fd3e922"
 "checksum foxbox_users 0.1.0 (git+https://github.com/fxbox/users.git)" = "<none>"
+"checksum fs2 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "640001e1bd865c7c32806292822445af576a6866175b5225aa2087ca5e3de551"
 "checksum fsevent 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)" = "740a52ca589381d87dd0d9960555de3320aa6d408326659e3bae88be9f71a125"
 "checksum fsevent-sys 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "72e33a926306442d961595c3a325864326ca4287795e106dae8993afe484ede6"
 "checksum gcc 0.3.40 (registry+https://github.com/rust-lang/crates.io-index)" = "872db9e59486ef2b14f8e8c10e9ef02de2bccef6363d7f34835dedb386b3d950"
@@ -1429,7 +1513,9 @@ dependencies = [
 "checksum mach 0.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "196697f416cf23cf0d3319cf5b2904811b035c82df1dfec2117fb457699bf277"
 "checksum matches 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "efd7622e3022e1a6eaa602c4cea8912254e5582c9c692e9167714182244801b1"
 "checksum memchr 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)" = "d8b629fb514376c675b98c1421e80b151d3817ac42d7c667717d282761418d20"
+"checksum memmap 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "065ce59af31c18ea2c419100bda6247dd4ec3099423202b12f0bd32e529fabd2"
 "checksum mime 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "b5c93a4bd787ddc6e7833c519b73a50883deb5863d76d9b71eb8216fb7f94e66"
+"checksum mime_guess 1.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "76da6df85047af8c0edfa53f48eb1073012ce1cc95c8fedc0a374f659a89dd65"
 "checksum mio 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a637d1ca14eacae06296a008fa7ad955347e34efcb5891cfd8ba05491a37907e"
 "checksum mio 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "410a1a0ff76f5a226f1e4e3ff1756128e65cd30166e39c3892283e2ac09d5b67"
 "checksum miow 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "c6b54090eaa23880441a80c4adec5fd6b4af1152a49c5e78f96a82469abc6942"
@@ -1443,6 +1529,7 @@ dependencies = [
 "checksum nix 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a0d95c5fa8b641c10ad0b8887454ebaafa3c92b5cd5350f8fc693adafd178e7b"
 "checksum nom 1.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "a5b8c256fd9471521bcb84c3cdba98921497f1a331cbc15b8030fc63b82050ce"
 "checksum notify 2.6.3 (registry+https://github.com/rust-lang/crates.io-index)" = "4e0e7eec936337952c4228b023007528a33b2fa039d96c2e8f32d764221a9c07"
+"checksum notify 3.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "13fdd4a6894329b193f38f03a88823ce721275fdfdb29820c44a30515033524e"
 "checksum num 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)" = "bde7c03b09e7c6a301ee81f6ddf66d7a28ec305699e3d3b056d2fc56470e3120"
 "checksum num-integer 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)" = "fb24d9bfb3f222010df27995441ded1e954f8f69cd35021f6bef02ca9552fb92"
 "checksum num-iter 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)" = "287a1c9969a847055e1122ec0ea7a5c5d6f72aad97934e131c83d5c08ab4e45c"
@@ -1459,6 +1546,8 @@ dependencies = [
 "checksum openzwave-sys 0.1.1 (git+https://github.com/fxbox/openzwave-rust)" = "<none>"
 "checksum pagekite 0.1.0 (git+https://github.com/fabricedesre/pagekite-rs.git)" = "<none>"
 "checksum persistent 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0c0aea7e6e026f9090c56aa7cda9d4ad6f182c717f0640cb03beace1f75a43d2"
+"checksum phf 0.7.20 (registry+https://github.com/rust-lang/crates.io-index)" = "0c6afb2057bb5f846a7b75703f90bc1cef4970c35209f712925db7768e999202"
+"checksum phf_codegen 0.7.20 (registry+https://github.com/rust-lang/crates.io-index)" = "6b63f121bf9a128f2172a65d8313a8e0e79d63874eeb4b4b7d82e6dda6b62f7c"
 "checksum phf_generator 0.7.20 (registry+https://github.com/rust-lang/crates.io-index)" = "50ffbd7970f75afa083c5dd7b6830c97b72b81579c7a92d8134ef2ee6c0c7eb0"
 "checksum phf_shared 0.7.20 (registry+https://github.com/rust-lang/crates.io-index)" = "286385a0e50d4147bce15b2c19f0cf84c395b0e061aaf840898a7bf664c2cfb7"
 "checksum pkg-config 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)" = "8cee804ecc7eaf201a4a207241472cc870e825206f6c031e3ee2a72fa425f2fa"
@@ -1521,6 +1610,7 @@ dependencies = [
 "checksum uuid 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "1a9ff57156caf7e22f37baf3c9d8f6ce8194842c23419dafcb0716024514d162"
 "checksum void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 "checksum walkdir 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "c66c0b9792f0a765345452775f3adbd28dde9d33f30d13e5dcc5ae17cf6f3780"
+"checksum walkdir 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "dd7c16466ecc507c7cb5988db03e6eab4aaeab89a5c37a29251fcfd3ac9b7afe"
 "checksum winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
 "checksum winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc"
 "checksum ws 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "7c47e9ca2f5c47d27f731b1bb9bb50cc05f9886bb84fbd52afa0ff97f4f61b06"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,13 +14,14 @@ exclude = [ "**/*.conf", "**/*.json",
 # We get the workspace's crates from the `path` definitions.
 
 [features]
-default = ["authentication", "zwave", "philips_hue", "thinkerbell", "ip_camera", "webpush"]
+default = ["authentication", "zwave", "philips_hue", "thinkerbell", "ip_camera", "webpush", "file_storage"]
 authentication = []
 zwave = ["openzwave-adapter"]
 philips_hue = []
 thinkerbell = ["foxbox_thinkerbell"]
 ip_camera = []
-webpush = []
+webpush = ["rust-crypto"]
+file_storage = ["walkdir", "mime_guess", "rust-crypto", "memmap", "notify"]
 
 [build-dependencies]
 pkg-config = "0.3"
@@ -47,15 +48,18 @@ hyper = "0.9"
 lazy_static = "^0.2"
 libc = "0.2.7"
 log = "0.3"
+memmap = { version = "0.5", optional = true }
+mime_guess = { version = "1.8", optional = true }
 mio = "0.6"
 mount = "0.2"
+notify = { version = "3.0", optional = true }
 nix = "0.7"
 openssl = "0.7.6"
 openssl-sys = "0.7.6"
 pagekite = { git = "https://github.com/fabricedesre/pagekite-rs.git" }
 rand = "0.3"
 router = "0.4"
-rust-crypto = "0.2.34"
+rust-crypto = { version = "0.2", optional = true }
 rustc-serialize = "0.3"
 rusqlite = "0.7"
 serde = "0.8"
@@ -67,6 +71,7 @@ unicase = "1.3.0"
 time = "0.1"
 timer = "0.1.6"
 url = "1.2"
+walkdir = { version = "1", optional = true }
 ws = { version = "0.5", features = ["ssl"] }
 
 [dependencies.iron]

--- a/src/adapters/file_storage/metadata.rs
+++ b/src/adapters/file_storage/metadata.rs
@@ -1,0 +1,123 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+extern crate crypto;
+extern crate memmap;
+extern crate mime_guess;
+
+use self::crypto::digest::Digest;
+use self::crypto::sha1::Sha1;
+use self::memmap::{Mmap, Protection};
+use self::mime_guess::guess_mime_type;
+use std;
+use std::fs::File;
+use std::path::{Path, PathBuf};
+
+#[derive(Clone, Debug, PartialEq, Serialize)]
+pub enum FileKind {
+    File,
+    Directory,
+}
+
+#[derive(Clone, Debug, Serialize)]
+pub struct FileMetadata {
+    pub path: PathBuf,
+    pub mime: String,
+    pub size: u64,
+    pub kind: FileKind,
+    pub hash: String, // TODO: switch to a byte array?
+}
+
+// Unused for now, but may allow finer tracking of file changes.
+#[allow(dead_code)]
+fn get_file_hash(path: &Path) -> Result<String, std::io::Error> {
+    let mut algo = Sha1::new();
+    let file = Mmap::open_path(&path, Protection::Read)?;
+    let bytes: &[u8] = unsafe { file.as_slice() };
+    algo.reset();
+    algo.input(bytes);
+
+    Ok(algo.result_str())
+}
+
+pub fn get_path_hash(path: &Path) -> String {
+    let mut algo = Sha1::new();
+    let s = format!("{}", path.display());
+    algo.reset();
+    algo.input(s.as_bytes());
+
+    algo.result_str()
+}
+
+pub fn get_file_content(path: &Path) -> Result<memmap::MmapView, std::io::Error> {
+    let file = Mmap::open_path(&path, Protection::Read)?;
+
+    Ok(file.into_view())
+}
+
+pub fn get_file_metadata(path: &Path) -> Result<FileMetadata, std::io::Error> {
+    let file = File::open(&path)?;
+    let fmeta = file.metadata()?;
+
+    let kind = if fmeta.is_dir() {
+        FileKind::Directory
+    } else {
+        FileKind::File
+    };
+
+    let hash = get_path_hash(path);
+
+    let mut mpath = PathBuf::new();
+    mpath.push(path);
+
+    Ok(FileMetadata {
+        path: mpath,
+        mime: format!("{}", guess_mime_type(path)),
+        size: fmeta.len(),
+        kind: kind,
+        hash: hash,
+    })
+}
+
+#[test]
+fn test_unknown_file_hash() {
+    let hash = get_file_hash(Path::new("./unknown.file"));
+    assert!(hash.is_err());
+}
+
+#[test]
+fn test_valid_file_hash() {
+    let hash = get_file_hash(Path::new("./package.json")).unwrap();
+    assert_eq!(hash, "103bfbff447830258032deedfc53d73ec87543c4");
+}
+
+#[test]
+fn test_unknown_file_metadata() {
+    let meta = get_file_metadata(Path::new("./unknown.file"));
+    assert!(meta.is_err());
+}
+
+#[test]
+fn test_valid_file_metadata() {
+    let path = Path::new("./package.json");
+    let meta = get_file_metadata(path).unwrap();
+    assert_eq!(meta.path, path);
+    assert_eq!(meta.mime, "application/json");
+    assert_eq!(meta.size, 1557);
+    assert_eq!(meta.kind, FileKind::File);
+    assert_eq!(meta.hash,
+               "9d106f6bdf655116e339da03a9b5609276c92191".to_owned());
+}
+
+#[test]
+fn test_valid_directory_metadata() {
+    let path = Path::new("./src");
+    let meta = get_file_metadata(path).unwrap();
+    assert_eq!(meta.path, path);
+    assert_eq!(meta.mime, "application/octet-stream");
+    assert_eq!(meta.size, 4096);
+    assert_eq!(meta.kind, FileKind::Directory);
+    assert_eq!(meta.hash,
+               "07901fccf6a039e8ea7ac1a1fecb3a710125e149".to_owned());
+}

--- a/src/adapters/file_storage/mod.rs
+++ b/src/adapters/file_storage/mod.rs
@@ -1,0 +1,335 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+///
+/// A file storage adapter. It watches files in a set of directories.
+/// Each file or directory is exposed as two getters:
+/// - id `node-info@$sha1`, which returns the file metadata.
+/// - id `node@$sha1`, which returns the file content.
+/// For a directory, the content is the metadata of leaf files.
+///
+
+extern crate notify;
+extern crate serde_json;
+extern crate walkdir;
+
+use foxbox_core::traits::Controller;
+use foxbox_taxonomy::adapter::*;
+use foxbox_taxonomy::manager::AdapterManager;
+use foxbox_taxonomy::api::{Error, InternalError, User};
+use foxbox_taxonomy::channel::*;
+use foxbox_taxonomy::services::{AdapterId, Id, Service, ServiceId};
+use foxbox_taxonomy::util::Maybe;
+use foxbox_taxonomy::values::{Binary, Json, format, Value};
+use std::collections::HashMap;
+use std::env;
+use std::path::PathBuf;
+use std::sync::{Arc, Mutex};
+use std::sync::mpsc::{channel, Sender};
+use std::time::Duration;
+use std::thread;
+use self::notify::{watcher, DebouncedEvent, Watcher, RecursiveMode};
+use self::walkdir::WalkDir;
+
+mod metadata;
+use self::metadata::*;
+
+static ADAPTER_ID: &'static str = "filestorage_adapter@link.mozilla.org";
+static ADAPTER_NAME: &'static str = "File Storage Adapter";
+static ADAPTER_VENDOR: &'static str = "team@link.mozilla.org";
+static ADAPTER_VERSION: [u32; 4] = [0, 0, 0, 0];
+
+// The internal messages for this adapter.
+#[derive(Debug)]
+enum FileStorageMessage {
+    Add(FileMetadata),
+    Remove(PathBuf),
+    Update(PathBuf),
+}
+
+pub struct FileStorageAdapter {
+    tx: Arc<Mutex<Sender<FileStorageMessage>>>,
+    dirs: Vec<String>, // The directories we are watching.
+    nodes: Arc<Mutex<HashMap<String, FileMetadata>>>,
+}
+
+impl Adapter for FileStorageAdapter {
+    fn id(&self) -> Id<AdapterId> {
+        adapter_id!(ADAPTER_ID)
+    }
+
+    fn name(&self) -> &str {
+        ADAPTER_NAME
+    }
+
+    fn vendor(&self) -> &str {
+        ADAPTER_VENDOR
+    }
+
+    fn version(&self) -> &[u32; 4] {
+        &ADAPTER_VERSION
+    }
+
+    fn fetch_values(&self,
+                    mut set: Vec<Id<Channel>>,
+                    _: User)
+                    -> ResultMap<Id<Channel>, Option<Value>, Error> {
+        set.drain(..)
+            .map(|id| {
+                // Get the hash from the channel id.
+                let channel_id = id.as_atom().as_ref();
+                let (cid, is_meta) = if channel_id.starts_with("file:content:") {
+                    (&channel_id[13..], false)
+                } else if channel_id.starts_with("file:metadata:") {
+                    (&channel_id[14..], true)
+                } else {
+                    // Unknown channel!
+                    error!("Unknown channel id: {}", channel_id);
+                    return (id.clone(),
+                            Err(Error::Internal(InternalError::NoSuchChannel(id.clone()))));
+                };
+
+                let nodes = self.nodes.lock().unwrap();
+                if let Some(meta) = nodes.get(cid) {
+                    // Ok, let's send the payload.
+                    if is_meta {
+                        info!("Serving metadata for {}", meta.path.display());
+                        return (id.clone(),
+                                Ok(Some(Value::new(Json(serde_json::to_value(&meta))))));
+                    } else {
+                        info!("Serving content for {}", meta.path.display());
+                        if meta.kind == FileKind::File {
+                            return (id.clone(), self.file_response(meta));
+                        } else {
+                            return (id.clone(), self.directory_response(meta, &nodes));
+                        }
+                    }
+                } else {
+                    // No such file hash.
+                    // TODO: return a 404 ?
+                    error!("Unknown file hash: {}", cid);
+                }
+
+                (id.clone(), Err(Error::Internal(InternalError::NoSuchChannel(id.clone()))))
+            })
+            .collect()
+    }
+
+    fn send_values(&self,
+                   mut values: HashMap<Id<Channel>, Value>,
+                   _: User)
+                   -> ResultMap<Id<Channel>, (), Error> {
+
+        values.drain()
+            .map(|(id, value)| (id.clone(), Err(Error::Internal(InternalError::NoSuchChannel(id)))))
+            .collect()
+    }
+}
+
+impl FileStorageAdapter {
+    pub fn init<C>(controller: C, adapt: &Arc<AdapterManager>) -> Result<(), Error>
+        where C: Controller
+    {
+        info!("Starting file storage adapter");
+
+        let (tx, rx) = channel::<FileStorageMessage>();
+
+        // TODO: support storing/retrieving multiple paths in the config file.
+        let config_store = controller.get_config();
+        let dirs = match config_store.get("filestorage", "path") {
+            Some(path) => vec![path],
+            None => {
+                match env::var("FOXBOX_STORAGE") {
+                    Ok(path) => vec![path],
+                    Err(_) => vec![],
+                }
+            }
+        };
+
+        let nodes = Arc::new(Mutex::new(HashMap::new()));
+        let fs = Arc::new(FileStorageAdapter {
+            dirs: dirs,
+            tx: Arc::new(Mutex::new(tx)),
+            nodes: nodes.clone(),
+        });
+
+        try!(adapt.add_adapter(fs.clone()));
+        let service_id = service_id!("filestorage@link.mozilla.org");
+        let adapter_id = adapter_id!(ADAPTER_ID);
+        try!(adapt.add_service(Service::empty(&service_id, &adapter_id)));
+
+        // TODO: Add upload setter
+
+        let adapt = adapt.clone();
+
+        // Spawn a thread that will listen to messages from the file watchers.
+        thread::Builder::new()
+            .name("FileStorageAdapter_main".to_owned())
+            .spawn(move || {
+                loop {
+                    if let Ok(msg) = rx.recv() {
+                        info!("FileStorageAdapter_main msg: {:?}", msg);
+                        match msg {
+                            FileStorageMessage::Add(meta) => {
+                                let hash = meta.hash.clone();
+                                 let is_file = meta.kind == FileKind::File;
+                                // Insert the metadata in our node tracker.
+                                nodes.lock().unwrap().insert(hash.clone(), meta);
+                                // Create the getters for this node.
+                                adapt.add_channel(Channel {
+                                    feature: Id::new("file/file-content"),
+                                    supports_fetch: Some(Signature::returns(Maybe::Required(if is_file { format::BINARY.clone() }
+                                    else { format::JSON.clone() }))),
+                                    id: Id::new(&format!("file:content:{}", hash.clone())),
+                                    service: service_id.clone(),
+                                    adapter: adapter_id.clone(),
+                                    ..Channel::default()
+                                }).unwrap();
+                                adapt.add_channel(Channel {
+                                    feature: Id::new("file/file-metadata"),
+                                    supports_fetch: Some(Signature::returns(Maybe::Required(format::JSON.clone()))),
+                                    id: Id::new(&format!("file:metadata:{}", hash.clone())),
+                                    service: service_id.clone(),
+                                    adapter: adapter_id.clone(),
+                                    ..Channel::default()
+                                }).unwrap();
+                            }
+                            FileStorageMessage::Remove(path) => {
+                                let hash = get_path_hash(&path);
+                                let mut nodes = nodes.lock().unwrap();
+                                if nodes.contains_key(&hash) {
+                                    // Remove both content and metadata channels.
+                                    nodes.remove(&hash);
+                                    adapt.remove_channel(&Id::new(&format!("file:content:{}", hash.clone()))).unwrap();
+                                    adapt.remove_channel(&Id::new(&format!("file:metadata:{}", hash.clone()))).unwrap();
+                                } else {
+                                    error!("Trying to remove untracked file: {}", path.display());
+                                }
+                            }
+                            FileStorageMessage::Update(path) => {
+                                let hash = get_path_hash(&path);
+                                let mut nodes = nodes.lock().unwrap();
+                                if nodes.contains_key(&hash) {
+                                    // Remove both content and metadata channels.
+                                    nodes.remove(&hash);
+                                    if let Ok(meta) = get_file_metadata(&path) {
+                                        nodes.insert(hash.clone(), meta);
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            })
+            .unwrap();
+
+        fs.walk_dirs();
+        fs.setup_notifier();
+
+        Ok(())
+    }
+
+    fn setup_notifier(&self) {
+        let dirs = self.dirs.clone();
+        let main_tx = self.tx.clone();
+        thread::Builder::new()
+            .name("FileStorageAdapter_notifier".to_owned())
+            .spawn(move || {
+                let (tx, rx) = channel();
+                let mut watcher = watcher(tx, Duration::from_secs(5)).unwrap();
+
+                for dir in dirs {
+                    watcher.watch(dir, RecursiveMode::Recursive).unwrap();
+                }
+                loop {
+                    if let Ok(event) = rx.recv() {
+                        match event {
+                            DebouncedEvent::Create(path) => {
+                                if let Ok(meta) = get_file_metadata(&path) {
+                                    main_tx.lock()
+                                        .unwrap()
+                                        .send(FileStorageMessage::Add(meta))
+                                        .unwrap();
+                                }
+                            }
+                            DebouncedEvent::Remove(path) => {
+                                main_tx.lock()
+                                    .unwrap()
+                                    .send(FileStorageMessage::Remove(path))
+                                    .unwrap();
+                            }
+                            DebouncedEvent::Rename(old_path, new_path) => {
+                                main_tx.lock()
+                                    .unwrap()
+                                    .send(FileStorageMessage::Remove(old_path))
+                                    .unwrap();
+                                if let Ok(meta) = get_file_metadata(&new_path) {
+                                    main_tx.lock()
+                                        .unwrap()
+                                        .send(FileStorageMessage::Add(meta))
+                                        .unwrap();
+                                }
+                            }
+                            DebouncedEvent::NoticeWrite(path) |
+                            DebouncedEvent::Write(path) => {
+                                main_tx.lock()
+                                    .unwrap()
+                                    .send(FileStorageMessage::Update(path))
+                                    .unwrap();
+                            }
+                            _ => info!("Unprocessed: {:?}", event),
+                        }
+                    }
+                }
+            })
+            .unwrap();
+    }
+
+    fn walk_dirs(&self) {
+        for dir in &self.dirs {
+            let dir = dir.clone();
+            let tx = self.tx.clone();
+            thread::Builder::new()
+                .name("FileStorageAdapter_walkdir".to_owned())
+                .spawn(move || {
+                    for entry in WalkDir::new(dir) {
+                        if let Ok(entry) = entry {
+                            if let Ok(meta) = get_file_metadata(entry.path()) {
+                                tx.lock().unwrap().send(FileStorageMessage::Add(meta)).unwrap();
+                            }
+                        }
+                    }
+                })
+                .unwrap();
+        }
+    }
+
+    fn file_response(&self, meta: &FileMetadata) -> Result<Option<Value>, Error> {
+        match get_file_content(&meta.path) {
+            Ok(rsp) => {
+                let data = unsafe { rsp.as_slice() };
+                Ok(Some(Value::new(Binary {
+                    data: Vec::from(data),
+                    mimetype: Id::new(&meta.mime),
+                })))
+            }
+            Err(err) => Err(Error::Internal(InternalError::GenericError(format!("{}", err)))),
+        }
+    }
+
+    fn directory_response(&self,
+                          meta: &FileMetadata,
+                          nodes: &HashMap<String, FileMetadata>)
+                          -> Result<Option<Value>, Error> {
+        let mut entries = Vec::new();
+        for entry in WalkDir::new(&meta.path).min_depth(1).max_depth(1) {
+            if let Ok(entry) = entry {
+                if let Some(fmeta) = nodes.get(&get_path_hash(entry.path())) {
+                    entries.push(fmeta.clone());
+                }
+            }
+        }
+        Ok(Some(Value::new(Json(serde_json::to_value(&entries)))))
+    }
+}

--- a/src/adapters/mod.rs
+++ b/src/adapters/mod.rs
@@ -28,6 +28,10 @@ mod thinkerbell;
 #[cfg(feature = "webpush")]
 pub mod webpush;
 
+/// An adapter providing file storage services.
+#[cfg(feature = "file_storage")]
+pub mod file_storage;
+
 use foxbox_taxonomy::manager::AdapterManager as TaxoManager;
 
 #[cfg(feature = "thinkerbell")]
@@ -104,6 +108,16 @@ impl<T: Controller> AdapterManager<T> {
         // nothing to see :)
     }
 
+    #[cfg(feature = "file_storage")]
+    fn start_file_storage(&self, manager: &Arc<TaxoManager>) {
+        file_storage::FileStorageAdapter::init(self.controller.clone(), manager).unwrap();
+    }
+
+    #[cfg(not(feature = "file_storage"))]
+    fn start_file_storage(&self, _: &Arc<TaxoManager>) {
+        // nothing to see :)
+    }
+
     #[cfg(feature = "ip_camera")]
     fn start_ip_camera(&self, manager: &Arc<TaxoManager>) {
         ip_camera::IPCameraAdapter::init(manager, self.controller.clone()).unwrap();
@@ -125,6 +139,7 @@ impl<T: Controller> AdapterManager<T> {
         self.start_philips_hue(manager);
         self.start_zwave(manager);
         self.start_tts(manager);
+        self.start_file_storage(manager);
     }
 
     /// Stop all the adapters.


### PR DESCRIPTION
Launch foxbox with:
`FOXBOX_STORAGE=$PATH_TO_WATCH ./run.sh -- -s foxbox -t knilxof.org:443` to expose the files in $PATH_TO_WATCH through this adapter.

@Yoric : I added support to watch values in controller.rs:89, and we get the events when adding new channels, but not when removing them (it's easy to test by touching a file in the watched directory, and then removing it).
Do you see anything that could cause that (I'm sure we don't drop the guard since we still receive new ChannelAdded events)?